### PR TITLE
[testing] removed fancy random index names in favor of simpler UUIDs

### DIFF
--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     implementation "io.github.scalapb-json:scalapb-circe_${scalaVersion}:${scalapbCirceVersion}"
     implementation "io.circe:circe-generic_${scalaVersion}:${circeVersion}"
     implementation "org.scalatest:scalatest_${scalaVersion}:3.0.8"
-    testImplementation 'com.oblac:nomen-est-omen:2.0.0'
     testImplementation 'org.apache.commons:commons-math3:3.6.1'
     testRuntime 'org.pegdown:pegdown:1.4.2'
 }


### PR DESCRIPTION
The random names were repeating more often than you'd like for something random.