### PR TITLE
Expand and document python client

### DIFF
--- a/client-python/elastiknn/api.py
+++ b/client-python/elastiknn/api.py
@@ -138,6 +138,44 @@ class Mapping:
                 }
             }
 
+    @dataclass(frozen=True)
+    class AngularLsh(Base):
+        dims: int
+        bands: int
+        rows: int
+
+        def to_dict(self):
+            return {
+                "type": "elastiknn_dense_float_vector",
+                "elastiknn": {
+                    "model": "lsh",
+                    "similarity": "angular",
+                    "dims": self.dims,
+                    "bands": self.bands,
+                    "rows": self.rows
+                }
+            }
+
+    @dataclass(frozen=True)
+    class L2LSH(Base):
+        dims: int
+        bands: int
+        rows: int
+        width: int
+
+        def to_dict(self):
+            return {
+                "type": "elastiknn_dense_float_vector",
+                "elastiknn": {
+                    "model": "lsh",
+                    "similarity": "l2",
+                    "dims": self.dims,
+                    "bands": self.bands,
+                    "rows": self.rows,
+                    "width": self.width
+                }
+            }
+
 
 class NearestNeighborsQuery:
 
@@ -223,4 +261,41 @@ class NearestNeighborsQuery:
         def with_vec(self, vec: Vec.Base):
             return NearestNeighborsQuery.HammingLsh(self.field, vec, self.similarity, self.candidates)
 
+    @dataclass(frozen=True)
+    class AngularLsh(Base):
+        field: str
+        vec: Vec.Base
+        similarity: Similarity = Similarity.Angular
+        candidates: int = 1000
+
+        def to_dict(self):
+            return {
+                "field": self.field,
+                "model": "lsh",
+                "similarity": self.similarity.name.lower(),
+                "candidates": self.candidates,
+                "vec": self.vec.to_dict()
+            }
+
+        def with_vec(self, vec: Vec.Base):
+            return NearestNeighborsQuery.AngularLsh(self.field, vec, self.similarity, self.candidates)
+
+    @dataclass(frozen=True)
+    class L2LSH(Base):
+        field: str
+        vec: Vec.Base
+        similarity: Similarity = Similarity.L2
+        candidates: int = 1000
+
+        def to_dict(self):
+            return {
+                "field": self.field,
+                "model": "lsh",
+                "similarity": self.similarity.name.lower(),
+                "candidates": self.candidates,
+                "vec": self.vec.to_dict()
+            }
+
+        def with_vec(self, vec: Vec.Base):
+            return NearestNeighborsQuery.L2LSH(self.field, vec, self.similarity, self.candidates)
 

--- a/docs/pages/python-client.md
+++ b/docs/pages/python-client.md
@@ -8,4 +8,23 @@ permalink: /python-client/
 
 # Python Client
 
-Work in progress :)
+The Python client provides a pythonic interface for using Elastiknn.
+This includes a low level client that roughly mirrors the [Scala client](/scala-client), as well as a higher level "model" that mimics the scikit-learn interface.
+The client gets published to PyPI and can be installed using `pip`.
+See the versions below.
+
+## Documentation
+
+- **<a href="/docs/pdoc" target="_blank">PDoc for latest the release</a>**
+- <a href="http://archive.elastiknn.klibisz.com" target="_blank">Archived docs from previous releases</a>
+
+## Versions
+
+|:--|:--|
+|Python Client, Release| [![Python Client Release Status][Badge-Python-Release]][Link-Python-Release]|
+
+
+<!-- Links -->
+
+[Link-Python-Release]: https://pypi.org/project/elastiknn-client/
+[Badge-Python-Release]: https://img.shields.io/pypi/v/elastiknn-client?style=for-the-badge "Python Release"

--- a/docs/pages/scala-client.md
+++ b/docs/pages/scala-client.md
@@ -15,7 +15,7 @@ A default instance for Scala `Future`s ships with the client.
 ## Documentation
 
 - **<a href="/docs/scaladoc/com/klibisz/elastiknn/client/" target="_blank">Scaladocs for the latest release</a>**
-- <a href="http://archive.elastiknn.klibisz.com" target="_blank">Scaladocs for previous releases</a>
+- <a href="http://archive.elastiknn.klibisz.com" target="_blank">Archived docs from previous releases</a>
 
 ## Versions
 
@@ -38,8 +38,3 @@ libraryDependencies += "com.klibisz.elastiknn" %% "client-elastic4s" % <version 
 ```
 
 For other build tools, please see the instructions alongside each artifact on the Sonatype repository (click the badges in the Versions table above).
-
-
-
-
-


### PR DESCRIPTION
Issue #67 reminded me that I hadn't written dataclasses for all of the mappings and queries.
This PR adds those dataclasses as well as a more complete python-client page in the docs.