### PR TITLE
Disable norms on fields used to store LSH hashes

### DIFF
--- a/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
+++ b/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
@@ -125,7 +125,7 @@ object Execute extends App {
     def search(testVecs: Stream[Throwable, Vec]) = {
       for {
         eknnClient <- ZIO.access[ElastiknnZioClient](_.get)
-        requests = testVecs.zipWithIndex.mapMPar(1) {
+        requests = testVecs.zipWithIndex.mapMPar(parallelism) {
           case (vec, i) =>
             for {
               (dur, res) <- eknnClient.nearestNeighbors(trainIndexName, eknnQuery.withVec(vec), k).timed

--- a/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
+++ b/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
@@ -256,14 +256,14 @@ object ExecuteLocal extends App {
 
   override def run(args: List[String]): URIO[Console, ExitCode] = {
     val s3Client = S3Utils.minioClient()
-    val dataset = Dataset.RandomDenseFloat(1000, 20000)
+    val dataset = Dataset.RandomSparseBool(1000, 10000)
     val exp = Experiment(
       dataset,
-      Mapping.AngularLsh(dataset.dims, 300, 1),
-      NearestNeighborsQuery.AngularLsh("vec", Vec.Empty(), 100),
-      Mapping.AngularLsh(dataset.dims, 300, 1),
+      Mapping.SparseIndexed(dataset.dims),
+      NearestNeighborsQuery.SparseIndexed("vec", Vec.Empty(), Similarity.Jaccard),
+      Mapping.SparseIndexed(dataset.dims),
       Seq(
-        Query(NearestNeighborsQuery.AngularLsh("vec", Vec.Empty(), 100), 100)
+        Query(NearestNeighborsQuery.SparseIndexed("vec", Vec.Empty(), Similarity.Jaccard), 100)
       )
     )
     s3Client.putObject("elastiknn-benchmarks", s"experiments/${exp.md5sum}.json", codecs.experimentCodec(exp).noSpaces)

--- a/plugin/src/main/scala/com/klibisz/elastiknn/mapper/VectorMapper.scala
+++ b/plugin/src/main/scala/com/klibisz/elastiknn/mapper/VectorMapper.scala
@@ -8,9 +8,10 @@ import com.klibisz.elastiknn.query.{ExactQuery, LshQuery, SparseIndexedQuery}
 import com.klibisz.elastiknn.{ELASTIKNN_NAME, VectorDimensionException}
 import io.circe.syntax._
 import io.circe.{Json, JsonObject}
-import org.apache.lucene.index.{IndexableField, Term}
+import org.apache.lucene.index.{IndexOptions, IndexableField, Term}
 import org.apache.lucene.search.similarities.BooleanSimilarity
 import org.apache.lucene.search.{DocValuesFieldExistsQuery, Query, TermInSetQuery, TermQuery}
+import org.apache.lucene.document
 import org.apache.lucene.util.BytesRef
 import org.elasticsearch.common.xcontent.{ToXContent, XContentBuilder}
 import org.elasticsearch.index.mapper.Mapper.TypeParser
@@ -56,6 +57,36 @@ object VectorMapper {
   private def incompatible(m: Mapping, v: Vec): Exception = new IllegalArgumentException(
     s"Mapping [${nospaces(m)}] is not compatible with vector [${nospaces(v)}]"
   )
+
+  class FieldType(typeName: String) extends MappedFieldType {
+
+    // We generally only care about the presence or absence of terms, not their counts or anything fancier.
+    this.setSimilarity(new SimilarityProvider("boolean", new BooleanSimilarity))
+    this.setOmitNorms(true)
+    this.setBoost(1f)
+    this.setTokenized(false)
+
+    override def typeName(): String = typeName
+    override def clone(): FieldType = new FieldType(typeName)
+    override def termQuery(value: Any, context: QueryShardContext): Query = value match {
+      case b: BytesRef => new TermQuery(new Term(name(), b))
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"Field [${name()}] of type [${typeName()}] doesn't support term queries with value of type [${value.getClass}]")
+    }
+
+    override def existsQuery(context: QueryShardContext): Query = new DocValuesFieldExistsQuery(name())
+  }
+
+  val simpleTokenFieldType: document.FieldType = {
+    val ft = new document.FieldType
+    ft.setIndexOptions(IndexOptions.DOCS)
+    ft.setTokenized(false)
+    ft.setOmitNorms(true)
+    ft.freeze()
+    ft
+  }
+
 }
 
 abstract class VectorMapper[V <: Vec: ElasticsearchCodec] { self =>
@@ -63,7 +94,7 @@ abstract class VectorMapper[V <: Vec: ElasticsearchCodec] { self =>
   val CONTENT_TYPE: String
   def checkAndCreateFields(mapping: Mapping, field: String, vec: V): Try[Seq[IndexableField]]
 
-  private val fieldType = new this.FieldType
+  private val fieldType = new VectorMapper.FieldType(CONTENT_TYPE)
 
   import com.klibisz.elastiknn.utils.CirceUtils.javaMapEncoder
 
@@ -138,23 +169,6 @@ abstract class VectorMapper[V <: Vec: ElasticsearchCodec] { self =>
         }
       }
     }
-  }
-
-  class FieldType extends MappedFieldType {
-
-    // We generally only care about the presence or absence of terms, not their counts or anything fancier.
-    this.setSimilarity(new SimilarityProvider("boolean", new BooleanSimilarity))
-
-    override def typeName(): String = CONTENT_TYPE
-    override def clone(): FieldType = new FieldType
-    override def termQuery(value: Any, context: QueryShardContext): Query = value match {
-      case b: BytesRef => new TermQuery(new Term(name(), b))
-      case _ =>
-        throw new UnsupportedOperationException(
-          s"Field [${name()}] of type [${typeName()}] doesn't support term queries with value of type [${value.getClass}]")
-    }
-
-    override def existsQuery(context: QueryShardContext): Query = new DocValuesFieldExistsQuery(name())
   }
 
 }

--- a/plugin/src/main/scala/com/klibisz/elastiknn/query/LshQuery.scala
+++ b/plugin/src/main/scala/com/klibisz/elastiknn/query/LshQuery.scala
@@ -8,7 +8,7 @@ import com.klibisz.elastiknn.api.{Mapping, Vec}
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.models.LshFunction
 import com.klibisz.elastiknn.storage.{StoredVec, UnsafeSerialization}
-import org.apache.lucene.document.{Field, FieldType}
+import org.apache.lucene.document.Field
 import org.apache.lucene.index._
 import org.apache.lucene.search._
 import org.apache.lucene.util.BytesRef


### PR DESCRIPTION
More about norms here: https://www.elastic.co/guide/en/elasticsearch/reference/current/norms.html

I setup a benchmark for the SparseIndexed mapping/query and noticed a lot of time spent in the Lucene80NormsProducer class. 

![image](https://user-images.githubusercontent.com/8015228/84854923-d499f600-b030-11ea-8225-3578cc9e6a69.png)

Setting `.omitNorms(true)` in a few places seems to get rid of that class in the sampler. It decreases the time for the `ExecuteLocal` benchmark from 100 seconds for 1000 serial queries to ~85 seconds for 1000 serial queries and 74 seconds to 62 seconds for parallel queries. I also noticed they used the same setting here: https://github.com/elastic/elasticsearch/pull/44374/files#diff-3e8da1369743959b46f7e6fa0d63c1afR56

![image](https://user-images.githubusercontent.com/8015228/84854940-e085b800-b030-11ea-8dc4-a781ebd5fd92.png)

I checked to see if it makes a difference with AngularLSH but didn't see a meaningful speedup. I didn't see the NormsProducer class in the sampler in either case.