### PR TITLE
Use ConstantScoreQuery to wrap TermQueries for SparseIndexedQuery and LshQuery

### DIFF
--- a/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
+++ b/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
@@ -254,10 +254,9 @@ object Execute extends App {
 
 object ExecuteLocal extends App {
 
-  override def run(args: List[String]): URIO[Console, ExitCode] = {
-    val s3Client = S3Utils.minioClient()
+  private val sparseIndexedExp = {
     val dataset = Dataset.RandomSparseBool(1000, 10000)
-    val exp = Experiment(
+    Experiment(
       dataset,
       Mapping.SparseIndexed(dataset.dims),
       NearestNeighborsQuery.SparseIndexed("vec", Vec.Empty(), Similarity.Jaccard),
@@ -266,6 +265,11 @@ object ExecuteLocal extends App {
         Query(NearestNeighborsQuery.SparseIndexed("vec", Vec.Empty(), Similarity.Jaccard), 100)
       )
     )
+  }
+
+  override def run(args: List[String]): URIO[Console, ExitCode] = {
+    val s3Client = S3Utils.minioClient()
+    val exp = sparseIndexedExp
     s3Client.putObject("elastiknn-benchmarks", s"experiments/${exp.md5sum}.json", codecs.experimentCodec(exp).noSpaces)
     Execute(
       Execute.Params(

--- a/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
+++ b/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
@@ -267,9 +267,22 @@ object ExecuteLocal extends App {
     )
   }
 
+  private val angularLshExp = {
+    val dataset = Dataset.RandomDenseFloat(1000, 10000)
+    Experiment(
+      dataset,
+      Mapping.AngularLsh(dataset.dims, 300, 1),
+      NearestNeighborsQuery.AngularLsh("vec", Vec.Empty(), 200),
+      Mapping.AngularLsh(dataset.dims, 300, 1),
+      Seq(
+        Query(NearestNeighborsQuery.AngularLsh("vec", Vec.Empty(), 200), 100)
+      )
+    )
+  }
+
   override def run(args: List[String]): URIO[Console, ExitCode] = {
     val s3Client = S3Utils.minioClient()
-    val exp = sparseIndexedExp
+    val exp = angularLshExp
     s3Client.putObject("elastiknn-benchmarks", s"experiments/${exp.md5sum}.json", codecs.experimentCodec(exp).noSpaces)
     Execute(
       Execute.Params(

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+- Using ConstantScoreQuery to wrap the TermQuery's used for matching hashes in Elastiknn's SparseIndexQuery and LshQuery.
+  Improves the SparseIndexedQuery benchmark from ~66 seconds to ~48 seconds.
+  Improves the LshQuery benchmark from ~37 seconds to ~31 seconds. 
+---
 - Omitting norms in LSH and sparse indexed queries. 
   This shaves ~15% of runtime off of a sparse indexed benchmark. 
   Results for LSH weren't as meaningful unfortunately.   

--- a/plugin/src/main/scala/com/klibisz/elastiknn/query/LshQuery.scala
+++ b/plugin/src/main/scala/com/klibisz/elastiknn/query/LshQuery.scala
@@ -75,7 +75,8 @@ object LshQuery {
       lshFunc(queryVec).foreach { h =>
         val term = new Term(field, new BytesRef(UnsafeSerialization.writeInt(h)))
         val termQuery = new TermQuery(term)
-        builder.add(new BooleanClause(termQuery, BooleanClause.Occur.SHOULD))
+        val constQuery = new ConstantScoreQuery(termQuery)
+        builder.add(new BooleanClause(constQuery, BooleanClause.Occur.SHOULD))
       }
       builder.setMinimumNumberShouldMatch(1)
       builder.build()

--- a/plugin/src/main/scala/com/klibisz/elastiknn/query/SparseIndexedQuery.scala
+++ b/plugin/src/main/scala/com/klibisz/elastiknn/query/SparseIndexedQuery.scala
@@ -6,7 +6,7 @@ import com.klibisz.elastiknn.api._
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.models.SparseIndexedSimilarityFunction
 import com.klibisz.elastiknn.storage.UnsafeSerialization
-import org.apache.lucene.document.{Field, FieldType, NumericDocValuesField}
+import org.apache.lucene.document.{Field, NumericDocValuesField}
 import org.apache.lucene.index._
 import org.apache.lucene.search._
 import org.apache.lucene.util.BytesRef
@@ -52,7 +52,8 @@ object SparseIndexedQuery {
       queryVec.trueIndices.foreach { ti =>
         val term = new Term(field, new BytesRef(UnsafeSerialization.writeInt(ti)))
         val termQuery = new TermQuery(term)
-        val clause = new BooleanClause(termQuery, BooleanClause.Occur.SHOULD)
+        val constQuery = new ConstantScoreQuery(termQuery)
+        val clause = new BooleanClause(constQuery, BooleanClause.Occur.SHOULD)
         builder.add(clause)
       }
       builder.setMinimumNumberShouldMatch(1)


### PR DESCRIPTION
Another modest improvement to SparseIndexedQuery and LshQuery.