### PR TITLE
Revise LSH parameter names

### DIFF
--- a/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/package.scala
+++ b/benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/package.scala
@@ -180,13 +180,14 @@ package object benchmarks {
         )
       )
       val lsh = for {
-        bitsProp <- Seq(0.1, 0.3, 0.5, 0.7, 0.9)
+        l <- 100 to 350 by 50
+        kProp <- Seq(0.01, 0.1, 0.20)
       } yield
         Experiment(
           dataset,
           Mapping.SparseBool(dataset.dims),
           NearestNeighborsQuery.Exact(vecName, Similarity.Hamming),
-          Mapping.HammingLsh(dataset.dims, (bitsProp * dataset.dims).toInt),
+          Mapping.HammingLsh(dataset.dims, L = l, k = (kProp * dataset.dims).toInt),
           for {
             k <- ks
             m <- Seq(1, 2, 10, 50)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+- Switched LSH parameter names to more canonical equivalents: `bands -> L`, `rows -> k`,
+  based on the [LSH wikipedia article](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#LSH_algorithm_for_nearest_neighbor_search) 
+  and material from Indyk, et. al, e.g. [these slides](http://people.csail.mit.edu/indyk/mmds.pdf).
+- Added a `k` parameter to Hamming LSH model, which lets you concatenate > 1 bits to form a single hash value.
+---
 - Switched scala client to store the ID as a doc-value field. This avoids decompressing the document source
   when reading results, which is about 40% faster on benchmarks for both exact and approx. search.
 ---

--- a/client-python/elastiknn/api.py
+++ b/client-python/elastiknn/api.py
@@ -95,8 +95,8 @@ class Mapping:
     @dataclass(frozen=True)
     class JaccardLsh(Base):
         dims: int
-        bands: int
-        rows: int
+        K: int
+        l: int
 
         def to_dict(self):
             return {
@@ -105,15 +105,16 @@ class Mapping:
                     "model": "lsh",
                     "similarity": "jaccard",
                     "dims": self.dims,
-                    "bands": self.bands,
-                    "rows": self.rows
+                    "K": self.K,
+                    "l": self.l
                 }
             }
 
     @dataclass(frozen=True)
     class HammingLsh(Base):
         dims: int
-        bits: int
+        L: int
+        k: int
 
         def to_dict(self):
             return {
@@ -122,7 +123,8 @@ class Mapping:
                     "model": "lsh",
                     "similarity": "jaccard",
                     "dims": self.dims,
-                    "bits": self.bits
+                    "L": self.L,
+                    "k": self.k
                 }
             }
 
@@ -141,8 +143,8 @@ class Mapping:
     @dataclass(frozen=True)
     class AngularLsh(Base):
         dims: int
-        bands: int
-        rows: int
+        K: int
+        l: int
 
         def to_dict(self):
             return {
@@ -151,17 +153,17 @@ class Mapping:
                     "model": "lsh",
                     "similarity": "angular",
                     "dims": self.dims,
-                    "bands": self.bands,
-                    "rows": self.rows
+                    "K": self.K,
+                    "l": self.l
                 }
             }
 
     @dataclass(frozen=True)
     class L2LSH(Base):
         dims: int
-        bands: int
-        rows: int
-        width: int
+        K: int
+        l: int
+        r: int
 
         def to_dict(self):
             return {
@@ -170,9 +172,9 @@ class Mapping:
                     "model": "lsh",
                     "similarity": "l2",
                     "dims": self.dims,
-                    "bands": self.bands,
-                    "rows": self.rows,
-                    "width": self.width
+                    "K": self.K,
+                    "l": self.l,
+                    "r": self.r
                 }
             }
 

--- a/core/src/main/java/com/klibisz/elastiknn/storage/UnsafeSerialization.java
+++ b/core/src/main/java/com/klibisz/elastiknn/storage/UnsafeSerialization.java
@@ -26,11 +26,11 @@ public class UnsafeSerialization {
     public static byte[] writeInt(final int i) {
         final int a = Math.abs(i);
         if (a <= Byte.MAX_VALUE) {
-            final byte[] buf = new byte[4]; // TODO: change me back
+            final byte[] buf = new byte[1];
             u.unsafe.putInt(buf, u.byteArrayOffset, i);
             return buf;
         } else if (a <= Short.MAX_VALUE) {
-            final byte[] buf = new byte[4]; // TODO: change me back
+            final byte[] buf = new byte[2];
             u.unsafe.putInt(buf, u.byteArrayOffset, i);
             return buf;
         } else {

--- a/core/src/main/java/com/klibisz/elastiknn/storage/UnsafeSerialization.java
+++ b/core/src/main/java/com/klibisz/elastiknn/storage/UnsafeSerialization.java
@@ -26,11 +26,11 @@ public class UnsafeSerialization {
     public static byte[] writeInt(final int i) {
         final int a = Math.abs(i);
         if (a <= Byte.MAX_VALUE) {
-            final byte[] buf = new byte[1];
+            final byte[] buf = new byte[4]; // TODO: change me back
             u.unsafe.putInt(buf, u.byteArrayOffset, i);
             return buf;
         } else if (a <= Short.MAX_VALUE) {
-            final byte[] buf = new byte[2];
+            final byte[] buf = new byte[4]; // TODO: change me back
             u.unsafe.putInt(buf, u.byteArrayOffset, i);
             return buf;
         } else {

--- a/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
@@ -87,7 +87,7 @@ package object api {
     final case class JaccardLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class HammingLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class DenseFloat(dims: Int) extends Mapping
-    final case class AngularLsh(dims: Int, bands: Int, rows: Int) extends Mapping
+    final case class AngularLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class L2Lsh(dims: Int, bands: Int, rows: Int, width: Int) extends Mapping
   }
 

--- a/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
@@ -88,7 +88,7 @@ package object api {
     final case class HammingLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class DenseFloat(dims: Int) extends Mapping
     final case class AngularLsh(dims: Int, L: Int, k: Int) extends Mapping
-    final case class L2Lsh(dims: Int, bands: Int, rows: Int, width: Int) extends Mapping
+    final case class L2Lsh(dims: Int, L: Int, k: Int, r: Int) extends Mapping
   }
 
   sealed trait NearestNeighborsQuery {

--- a/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
@@ -1,7 +1,5 @@
 package com.klibisz.elastiknn
 
-import jdk.jfr.Experimental
-
 import scala.util.Random
 
 package object api {
@@ -86,7 +84,7 @@ package object api {
   object Mapping {
     final case class SparseBool(dims: Int) extends Mapping
     final case class SparseIndexed(dims: Int) extends Mapping
-    final case class JaccardLsh(dims: Int, bands: Int, rows: Int) extends Mapping
+    final case class JaccardLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class HammingLsh(dims: Int, bits: Int) extends Mapping
     final case class DenseFloat(dims: Int) extends Mapping
     final case class AngularLsh(dims: Int, bands: Int, rows: Int) extends Mapping

--- a/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/api/package.scala
@@ -85,7 +85,7 @@ package object api {
     final case class SparseBool(dims: Int) extends Mapping
     final case class SparseIndexed(dims: Int) extends Mapping
     final case class JaccardLsh(dims: Int, L: Int, k: Int) extends Mapping
-    final case class HammingLsh(dims: Int, bits: Int) extends Mapping
+    final case class HammingLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class DenseFloat(dims: Int) extends Mapping
     final case class AngularLsh(dims: Int, bands: Int, rows: Int) extends Mapping
     final case class L2Lsh(dims: Int, bands: Int, rows: Int, width: Int) extends Mapping

--- a/core/src/main/scala/com/klibisz/elastiknn/models/LshFunction.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/models/LshFunction.scala
@@ -90,6 +90,7 @@ object LshFunction {
 
     import mapping._
     private val rng: Random = new Random(0)
+    private val zeroUntilL: Array[Int] = (0 until L).toArray
     private val barrZero: Array[Byte] = writeInt(0)
     private val barrOne: Array[Byte] = writeInt(1)
 
@@ -120,7 +121,7 @@ object LshFunction {
     }
 
     override def apply(vec: Vec.SparseBool): Array[Array[Byte]] = {
-      val hashBuffers = (0 until L).toArray.map { l =>
+      val hashBuffers = zeroUntilL.map { l =>
         val lbarr = writeInt(l)
         val buff = new ArrayBuffer[Byte](lbarr.length + k) // Each array will contain the l int plus k 0s and 1s.
         buff.appendAll(lbarr)
@@ -144,7 +145,7 @@ object LshFunction {
           ixTrueIndices += 1
         }
       }
-      // Traverse the remaining sampled positions, if any.
+      // Traverse the remaining sampled positions, if any, appending zeros.
       while (ixSampledPositions < sampledPositions.length) {
         val pos = sampledPositions(ixSampledPositions)
         pos.hashIndexes.foreach(hi => hashBuffers(hi).appendAll(barrZero))

--- a/core/src/main/scala/com/klibisz/elastiknn/models/LshFunction.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/models/LshFunction.scala
@@ -107,9 +107,19 @@ object LshFunction {
 
       // If L * k <= dims, just sample vec indices once, guaranteeing no repetition.
       val pairs: Array[Pair] = if ((L * k) <= dims) {
-        sampleVecIndicesWithoutRepetition(L * k).zipWithIndex.map(Pair.tupled)
+//        val q = sampleVecIndicesWithoutRepetition(L * k)
+//          .grouped(k)
+//          .zipWithIndex
+//          .flatMap {
+//            case (hii, vi) => hii.map(hi => Pair(vi, hi))
+//          }
+//          .toArray
+//        require(q.map(_.hashIndex) < L)
+        sampleVecIndicesWithoutRepetition(L * k).zipWithIndex.map {
+          case (vi, hi) => Pair(vi, hi % L)
+        }
       } else {
-        (0 until L).toArray.flatMap(hi => sampleVecIndicesWithoutRepetition(k).map(vi => Pair(hi, vi)))
+        zeroUntilL.flatMap(hi => sampleVecIndicesWithoutRepetition(k).map(vi => Pair(vi, hi)))
       }
 
       pairs

--- a/core/src/main/scala/com/klibisz/elastiknn/storage/BitBuffer.scala
+++ b/core/src/main/scala/com/klibisz/elastiknn/storage/BitBuffer.scala
@@ -1,0 +1,29 @@
+package com.klibisz.elastiknn.storage
+
+/**
+  * Minimal abstraction to simplify storing a series of bits as a single scalar value, convertible to a byte array.
+  */
+sealed trait BitBuffer {
+  def putOne(): Unit
+  def putZero(): Unit
+  def toByteArray: Array[Byte]
+}
+
+object BitBuffer {
+
+  class IntBuffer(barr: Array[Byte] = Array.empty) extends BitBuffer {
+    private var buf = 0
+    private var i = 0
+    override def putOne(): Unit = {
+      buf += IntBuffer.powers(i)
+      i += 1
+    }
+    override def putZero(): Unit = i += 1
+    override def toByteArray: Array[Byte] = barr ++ UnsafeSerialization.writeInt(buf)
+  }
+
+  object IntBuffer {
+    private val powers = (0 until 32).map(1 << _).toArray
+  }
+
+}

--- a/docs/pages/api.md
+++ b/docs/pages/api.md
@@ -158,11 +158,13 @@ PUT /my-index/_mapping
 
 ### Jaccard LSH Mapping
 
-The Jaccard LSH Model enables approximate queries for the Jaccard similarity function on sparse bool vectors using the [Minhash algorithm](https://en.wikipedia.org/wiki/MinHash).
+Uses the [Minhash algorithm](https://en.wikipedia.org/wiki/MinHash) to hash and store sparse bool vectors such that they
+support approximate Jaccard similarity queries.
 
-The implementation is influenced by Chapter 3 of [Mining Massive Datasets.](http://www.mmds.org/) the [Spark MinHash implementation](https://spark.apache.org/docs/2.2.3/ml-features.html#minhash-for-jaccard-distance), the [tdebatty/java-LSH Github project](https://github.com/tdebatty/java-LSH), and the [Minhash for Dummies](http://matthewcasperson.blogspot.com/2013/11/minhash-for-dummies.html) blog post.
-
-The total number of hash functions computed is `bands * rows`, and the total number indexed is `bands`.
+The implementation is influenced by Chapter 3 of [Mining Massive Datasets.](http://www.mmds.org/), 
+the [Spark MinHash implementation](https://spark.apache.org/docs/2.2.3/ml-features.html#minhash-for-jaccard-distance), 
+the [tdebatty/java-LSH Github project](https://github.com/tdebatty/java-LSH), 
+and the [Minhash for Dummies](http://matthewcasperson.blogspot.com/2013/11/minhash-for-dummies.html) blog post.
 
 ```json
 PUT /my-index/_mapping
@@ -174,8 +176,8 @@ PUT /my-index/_mapping
                 "dims": 25000,                      # 2
                 "model": "lsh",                     # 3
                 "similarity": "jaccard",            # 4
-                "bands": 99,                        # 5
-                "rows": 1,                          # 6
+                "L": 99,                            # 5
+                "k": 1                              # 6
             }
         }
     }
@@ -188,16 +190,17 @@ PUT /my-index/_mapping
 |2|Vector dimensionality.|
 |3|Model type.|
 |4|Similarity.|
-|5|Number of bands. Sometimes called the number of tables or `L`. Generally, increasing the number of bands increases [recall](https://en.wikipedia.org/wiki/Precision_and_recall#Recall) at the cost of additional compuation.|
-|6|Number of rows per band. Sometimes called the number of hash functions (per table) or `k`. Generally, increasing the number of rows increases [precision](https://en.wikipedia.org/wiki/Precision_and_recall#Precision) at the cost of additional computation.|
+|5|Number of hash tables. Generally, increasing this value increases recall.|
+|6|Number of hash functions combined to form a single hash value. Generally, increasing this value increases precision.|
 
 ### Hamming LSH Mapping
 
-Enables approximate queries for the Hamming similarity function on sparse bool vectors using the [Bit-Sampling algorithm](http://mlwiki.org/index.php/Bit_Sampling_LSH).
+Uses the [Bit-Sampling algorithm](http://mlwiki.org/index.php/Bit_Sampling_LSH) to hash and store sparse bool vectors
+such that they support approximate Hamming similarity queries.
 
-The implementation is influenced by Chapter 3 of [Mining Massive Datasets.](http://www.mmds.org/)
-
-The total number of hash functions computed and indexed for each vector is `bits`.
+Only difference from the canonical bit-sampling method is that it samples and combines `k` bits to form a single hash value.
+For example, if you set `L = 100, k = 3`, it samples `100 * 3 = 300` bits from the vector and concatenates sets of 3 
+bits to form each hash value, for a total of 100 hash values.
 
 ```json
 PUT /my-index/_mapping
@@ -209,7 +212,8 @@ PUT /my-index/_mapping
                 "dims": 25000,                      # 2
                 "model": "lsh",                     # 3
                 "similarity": "hamming",            # 4
-                "bits": 99,                         # 5
+                "L": 99,                            # 5
+                "k": 2
             }
         }
     }
@@ -222,15 +226,15 @@ PUT /my-index/_mapping
 |2|Vector dimensionality.|
 |3|Model type.|
 |4|Similarity.|
-|5|Number of bits (indices) to sample from each vector. This should not exceed the dimensionality. Generally, increasing the number of bits increases [recall.](https://en.wikipedia.org/wiki/Precision_and_recall#Recall)|
+|5|Number of hash tables. Generally, increasing this value increases recall.|
+|6|Number of hash functions combined to form a single hash value. Generally, increasing this value increases precision.|
 
 ### Angular LSH Mapping
 
-Enables approximate queries for the Angular similarity function on dense float vectors using the [Random Projection algorithm.](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Random_projection)
+Uses the [Random Projection algorithm](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Random_projection)
+to hash and store dense float vectors such that they support approximate Angular similarity queries.
 
 The implementation is influenced by Chapter 3 of [Mining Massive Datasets.](http://www.mmds.org/)
-
-The total number of hash functions computed is `bands * rows`, and the total number indexed is `bands`.
 
 ```json
 PUT /my-index/_mapping
@@ -242,8 +246,8 @@ PUT /my-index/_mapping
                 "dims": 100,                        # 2
                 "model": "lsh",                     # 3
                 "similarity": "angular",            # 4
-                "bands": 99,                        # 5
-                "rows": 1,                          # 6
+                "L": 99,                            # 5
+                "k": 1                              # 6
             }
         }
     }
@@ -256,16 +260,15 @@ PUT /my-index/_mapping
 |2|Vector dimensionality.|
 |3|Model type.|
 |4|Similarity.|
-|5|Number of bands. Sometimes called the number of tables or `L`. Generally, increasing the number of bands increases [recall](https://en.wikipedia.org/wiki/Precision_and_recall#Recall) at the cost of additional compuation.|
-|6|Number of rows per band. Sometimes called the number of hash functions (per table) or `k`. Generally, increasing the number of rows increases [precision](https://en.wikipedia.org/wiki/Precision_and_recall#Precision) at the cost of additional computation.|
+|5|Number of hash tables. Generally, increasing this value increases recall.|
+|6|Number of hash functions combined to form a single hash value. Generally, increasing this value increases precision.|
 
 ### L2 LSH Mapping
 
-Enables approximate queries for the L2 (Euclidean) similarity function on dense float vectors using the [Stable Distributions method.](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Stable_distributions)
+Uses the [Stable Distributions method](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Stable_distributions)
+to hash and store dense float vectors such that they support approximate L2 (Euclidean) similarity queries.
 
 The implementation is influenced by Chapter 3 of [Mining Massive Datasets.](http://www.mmds.org/)
-
-The total number of hash functions computed is `bands * rows`, and the total number indexed is `bands`.
 
 ```json
 PUT /my-index/_mapping
@@ -277,9 +280,9 @@ PUT /my-index/_mapping
                 "dims": 100,                        # 2
                 "model": "lsh",                     # 3
                 "similarity": "l2",                 # 4
-                "bands": 99,                        # 5
-                "rows": 1,                          # 6
-                "width": 3,                         # 7
+                "L": 99,                            # 5
+                "k": 1,                             # 6
+                "r": 3                              # 7
             }
         }
     }
@@ -292,13 +295,16 @@ PUT /my-index/_mapping
 |2|Vector dimensionality.|
 |3|Model type.|
 |4|Similarity.|
-|5|Number of bands. Sometimes called the number of tables or `L`. Generally, increasing the number of bands increases [recall](https://en.wikipedia.org/wiki/Precision_and_recall#Recall) at the cost of additional compuation.|
-|6|Number of rows per band. Sometimes called the number of hash functions (per table) or `k`. Generally, increasing the number of rows increases [precision](https://en.wikipedia.org/wiki/Precision_and_recall#Precision) at the cost of additional computation.|
-|7|Integer bucket width. This determines how close two vectors have to be, when projected onto a third common vector, in order for the two vectors to fall in the same bucket. Typical values are low single-digit integers.|
+|5|Number of hash tables. Generally, increasing this value increases recall.|
+|6|Number of hash functions combined to form a single hash value. Generally, increasing this value increases precision.|
+|7|Integer bucket width. This determines how close two vectors have to be, when projected onto a third common vector, in order for the two vectors to share a hash value. Typical values are low single-digit integers.|
 
 ## Vectors
 
-You need to specify vectors in your REST requests when indexing documents containing a vector and when running queries with a literal query vector. In both cases you use the same JSON structure to define vectors. The examples below show the indexing case; the query case will be covered later.
+You need to specify vectors in your REST requests when indexing documents containing a vector and when running queries
+with a literal query vector. 
+In both cases you use the same JSON structure to define vectors. 
+The examples below show the indexing case; the query case will be covered later.
 
 ### elastiknn_sparse_bool_vector
 
@@ -659,13 +665,14 @@ Perhaps there will be a more cohesive way to present these in the future.
 ### Storing Model Parameters
 
 The LSH models all use randomized parameters to hash vectors. 
-The simplest example is the bit-sampling model for Hamming similarity, which is parameterized by a list of randomly sampled indices. 
-A more complicated example is the stable distributions model for L2 similarity, which is parameterized by a set of random unit vectors and a set of random bias values. 
+The simplest example is the bit-sampling model for Hamming similarity, parameterized by a list of randomly sampled indices. 
+A more complicated example is the stable distributions model for L2 similarity, parameterized by a set of random unit vectors 
+and a set of random bias scalars.
 These parameters aren't actually stored anywhere in Elasticsearch. 
-Rather, they are lazily re-computed from a fixed random seed each time they are needed. 
-The advantage of this is that you don't have to worry about storing and synchronizing potentially large parameter documents somewhere in the cluster. 
+Rather, they are lazily re-computed from a fixed random seed (0) each time they are needed. 
+The advantage of this is that it avoids storing and synchronizing potentially large parameter blobs in the cluster. 
 The disadvantage is that it's expensive to re-compute the randomized parameters. 
-So instead we keep an internal cache of models, keyed on the model hyperparameters (e.g. `bands`, `rows`, etc.). 
+So instead we keep a cache of models in each Elasticsearch node, keyed on the model hyperparameters (e.g. `L`, `k`, etc.). 
 The hyperparameters are stored inside the mappings where they are originally defined.
 
 ### Transforming and Indexing Vectors

--- a/examples/demo/webapp/app/models/Dataset.scala
+++ b/examples/demo/webapp/app/models/Dataset.scala
@@ -70,11 +70,11 @@ object Dataset extends ElastiknnRequests {
                 (f, v) => NearestNeighborsQuery.SparseIndexed(f, Similarity.Hamming, v)),
         example("Hamming LSH #1",
                 "mnist-hamming-lsh-1",
-                Mapping.HammingLsh(784, 100),
+                Mapping.HammingLsh(784, 100, 1),
                 (f, v) => NearestNeighborsQuery.HammingLsh(f, 100, v)),
         example("Hamming LSH #2",
                 "mnist-hamming-lsh-2",
-                Mapping.HammingLsh(784, 100),
+                Mapping.HammingLsh(784, 100, 1),
                 (f, v) => NearestNeighborsQuery.HammingLsh(f, 20, v)),
       )
     ),

--- a/testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
@@ -106,8 +106,8 @@ class ElasticsearchCodecSuite extends FunSuite with Matchers {
       |  "dims": 100,
       |  "model": "lsh",
       |  "similarity": "jaccard",
-      |  "bands": 99,
-      |  "rows": 1
+      |  "L": 99,
+      |  "k": 1
       | }
       |}
       |""".stripMargin shouldDecodeTo [Mapping] Mapping.JaccardLsh(100, 99, 1)

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -127,12 +127,12 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.13,
-        NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.24,
+        NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.15,
+        NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.25,
         NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.44
       )
     )
-  ).drop(8).take(2)
+  )
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
     for {

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -129,7 +129,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.44
       )
     )
-  )
+  ).drop(3).take(2)
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
     for {

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -92,11 +92,14 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
       )
     ),
     Test(
-      Mapping.HammingLsh(dims, dims * 7 / 10, 1),
-      Seq(
-        NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.89,
-        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.97
-      )
+      // Increasing k increases recall up to a point.
+      Mapping.HammingLsh(dims, dims * 2 / 5, 2),
+      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.82)
+    ),
+    Test(
+      // But increasing it too far decreases recall.
+      Mapping.HammingLsh(dims, dims * 2 / 5, 4),
+      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.65)
     ),
     // Angular Lsh
     Test(
@@ -129,7 +132,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.44
       )
     )
-  ).drop(5).take(2)
+  )
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
     for {

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -85,8 +85,8 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
     Test(
       Mapping.HammingLsh(dims, dims * 1 / 2, 1),
       Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
         NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.71,
         NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.86
       )
@@ -129,7 +129,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.44
       )
     )
-  ).drop(5).take(1)
+  ).drop(5).take(2)
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
     for {

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -83,16 +83,16 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
     ),
     // Hamming LSH
     Test(
-      Mapping.HammingLsh(dims, dims * 5 / 10),
+      Mapping.HammingLsh(dims, dims * 1 / 2, 1),
       Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
         NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.71,
-        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.86
+//        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.86
       )
     ),
     Test(
-      Mapping.HammingLsh(dims, dims * 7 / 10),
+      Mapping.HammingLsh(dims, dims * 7 / 10, 1),
       Seq(
         NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.89,
         NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.97
@@ -129,7 +129,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.44
       )
     )
-  ).drop(3).take(2)
+  ).drop(5).take(1)
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
     for {

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -132,7 +132,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.44
       )
     )
-  )
+  ).drop(8).take(2)
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
     for {

--- a/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -88,7 +88,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
 //        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
 //        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
         NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.71,
-//        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.86
+        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.86
       )
     ),
     Test(

--- a/testing/src/test/scala/com/klibisz/elastiknn/storage/BitBufferSuite.scala
+++ b/testing/src/test/scala/com/klibisz/elastiknn/storage/BitBufferSuite.scala
@@ -1,0 +1,36 @@
+package com.klibisz.elastiknn.storage
+
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.util.Random
+
+class BitBufferSuite extends FunSuite with Matchers {
+
+  test("IntBuffer manual test") {
+    val ib = new BitBuffer.IntBuffer
+    ib.putOne() // +1 = 1
+    ib.putZero() // +0 = 1
+    ib.putOne() // +4 = 5
+    ib.putOne() // +8 = 13
+    ib.toByteArray shouldBe UnsafeSerialization.writeInt(13)
+  }
+
+  test("IntBuffer randomized test") {
+    val rng = new Random(0)
+    for (_ <- 0 until 100) {
+      val len = rng.nextInt(32)
+      val bits = (0 until len).map(_ => rng.nextInt(2))
+      val prefix = UnsafeSerialization.writeInt(rng.nextInt(Int.MaxValue))
+      val expected = bits.zipWithIndex
+        .map {
+          case (b, i) => b * math.pow(2, i)
+        }
+        .sum
+        .toInt
+      val bitBuf = new BitBuffer.IntBuffer(prefix)
+      bits.foreach(b => if (b == 0) bitBuf.putZero() else bitBuf.putOne())
+      bitBuf.toByteArray shouldBe prefix ++ UnsafeSerialization.writeInt(expected)
+    }
+  }
+
+}


### PR DESCRIPTION
Re #96 

Parameter names are now based on the conventions in the [LSH wikipedia article](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#LSH_algorithm_for_nearest_neighbor_search) and material from Indyk, et. al, e.g. [these slides](http://people.csail.mit.edu/indyk/mmds.pdf).

Also improved some internal conventions, e.g. using BitBuffer to abstract bit operations.