### PR TITLE
Limit number of doc ids emitted from MatchHashesAndScoreQuery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+- Updated `MatchHashesAndScoreQuery` so that approximate queries will emit no more than `candidates` doc IDs.
+  This slightly decreases recall, since the previous implementation could emit > `candidates` IDs. 
+---
 - Support sparse bool query vectors with unsorted true indices.
 ---
 - Added new submodules which can be used without Elasticsearch:

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/KthGreatest.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/KthGreatest.java
@@ -1,6 +1,18 @@
 package org.apache.lucene.search;
 
 public class KthGreatest {
+
+    public static class KthGreatestResult {
+        public final short max;
+        public final short kthGreatest;
+        public final int numGreaterThanKthGreatest;
+        public KthGreatestResult(short max, short kthGreatest, int numGreaterThanKthGreatest) {
+            this.max = max;
+            this.kthGreatest = kthGreatest;
+            this.numGreaterThanKthGreatest = numGreaterThanKthGreatest;
+        }
+    }
+
     /**
      * Find the kth greatest value in the given array of shorts in O(N) time and space.
      * Works by creating a histogram of the array values and traversing the histogram in reverse order.
@@ -11,7 +23,7 @@ public class KthGreatest {
      * @param k the desired largest value.
      * @return the kth largest value.
      */
-    public static short kthGreatest(short[] arr, int k) {
+    public static KthGreatestResult kthGreatest(short[] arr, int k) {
         if (arr.length == 0) {
             throw new IllegalArgumentException("Array must be non-empty");
         } else if (k < 0 || k >= arr.length) {
@@ -35,15 +47,16 @@ public class KthGreatest {
             }
 
             // Find the kth largest value by iterating from the end of the histogram.
-            int geqk = 0;
-            short kthLargest = max;
-            while (kthLargest >= min) {
-                geqk += hist[kthLargest - min];
-                if (geqk > k) break;
-                else kthLargest--;
+            int numGreaterEqual = 0;
+            short kthGreatest = max;
+            while (kthGreatest >= min) {
+                numGreaterEqual += hist[kthGreatest - min];;
+                if (numGreaterEqual > k) break;
+                else kthGreatest--;
             }
+            int numGreater = numGreaterEqual - hist[kthGreatest - min];
 
-            return kthLargest;
+            return new KthGreatestResult(max, kthGreatest, numGreater);
         }
     }
 }

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -4,6 +4,7 @@ import com.klibisz.elastiknn.models.HashAndFreq;
 import org.apache.lucene.index.*;
 import org.apache.lucene.util.BytesRef;
 
+import javax.print.Doc;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Set;
@@ -66,34 +67,61 @@ public class MatchHashesAndScoreQuery extends Query {
                 if (candidates >= numDocsInSegment) return DocIdSetIterator.all(indexReader.maxDoc());
                 else {
                     // Compute the kth greatest count to use as a lower bound for picking candidates.
-                    int minCandidateCount = KthGreatest.kthGreatest(counts, candidates);
+                    KthGreatest.KthGreatestResult kgr = KthGreatest.kthGreatest(counts, candidates);
 
-                    // If that lower bound is 0, none of the documents in this segment have matched, so return an empty iterator.
-                    if (minCandidateCount == 0) return DocIdSetIterator.empty();
+                    // If none of the docs in the segment matched, return an empty iterator.
+                    if (kgr.max == 0) return DocIdSetIterator.empty();
 
-                    // Otherwise return an iterator over the doc ids >= the min candidate count.
+                        // Otherwise return an iterator over the doc ids >= the min candidate count.
                     else return new DocIdSetIterator() {
 
                         // Starting at -1 instead of 0 ensures the 0th document is not emitted unless it's a true candidate.
-                        private int doc = -1;
+                        private int docId = -1;
+
+                        // Track the number of ids emitted, and the number of ids with count = kgr.kthGreatest emitted.
+                        private int numEmitted = 0;
+                        private int numEq = 0;
 
                         @Override
                         public int docID() {
-                            return doc;
+                            return docId;
                         }
 
                         @Override
                         public int nextDoc() {
-                            // Increment doc until it exceeds the min candidate count.
-                            do doc++;
-                            while (doc < counts.length && counts[doc] < minCandidateCount);
-                            if (doc == counts.length) return DocIdSetIterator.NO_MORE_DOCS;
-                            else return docID();
+
+                            // Emits no more than the requested number of candidates.
+                            if (numEmitted == candidates) {
+                                docId = DocIdSetIterator.NO_MORE_DOCS;
+                                return docID();
+                            }
+
+                            // Ensure that docs with count = kgr.kthGreatest are only emitted when there are fewer
+                            // than `candidates` docs with count > kgr.kthGreatest.
+                            while (true) {
+                                if (docId < counts.length) docId++;
+
+                                if (docId == counts.length) {
+                                    docId = DocIdSetIterator.NO_MORE_DOCS;
+                                    return docID();
+                                }
+                                if (counts[docId] > kgr.kthGreatest) {
+                                    numEmitted++;
+                                    return docID();
+                                }
+                                if (counts[docId] == kgr.kthGreatest && numEq < candidates - kgr.numGreaterThanKthGreatest) {
+                                    numEq++;
+                                    numEmitted++;
+                                    return docID();
+                                }
+
+                            }
+
                         }
 
                         @Override
                         public int advance(int target) {
-                            while (doc < target) nextDoc();
+                            while (docId < target) nextDoc();
                             return docID();
                         }
 
@@ -110,11 +138,12 @@ public class MatchHashesAndScoreQuery extends Query {
 
             @Override
             public Explanation explain(LeafReaderContext context, int doc) {
-                return Explanation.match( 0, "If someone know what this should return, please submit a PR. :)");
+                return Explanation.match( 0, "If someone knows what this should return, please submit a PR. :)");
             }
 
             @Override
             public Scorer scorer(LeafReaderContext context) throws IOException {
+
                 ScoreFunction scoreFunction = scoreFunctionBuilder.apply(context);
                 short[] counts = countMatches(context);
                 DocIdSetIterator disi = buildDocIdSetIterator(counts);

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQueryRecallSuite.scala
@@ -159,7 +159,7 @@ class NearestNeighborsQueryRecallSuite extends AsyncFunSuite with Matchers with 
         NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.36,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.31,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.51,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.3,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.43

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/search/KthGreatestSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/search/KthGreatestSuite.scala
@@ -7,13 +7,7 @@ import scala.util.Random
 
 class KthGreatestSuite extends FunSuite with Matchers {
 
-  test("kthGreatest example") {
-    val counts: Array[Short] = Array(2, 2, 8, 7, 4, 4)
-    val res = KthGreatest.kthGreatest(counts, 3)
-    res shouldBe 4
-  }
-
-  test("kthGreatest bad args") {
+  test("bad args") {
     an[IllegalArgumentException] shouldBe thrownBy {
       KthGreatest.kthGreatest(Array.empty, 3)
     }
@@ -25,7 +19,15 @@ class KthGreatestSuite extends FunSuite with Matchers {
     }
   }
 
-  test("kthGreatest randomized") {
+  test("example") {
+    val counts: Array[Short] = Array(2, 2, 8, 7, 4, 4)
+    val res = KthGreatest.kthGreatest(counts, 3)
+    res.max shouldBe 8
+    res.kthGreatest shouldBe 4
+    res.numGreaterThanKthGreatest shouldBe 2
+  }
+
+  test("randomized") {
     val seed = System.currentTimeMillis()
     val rng = new Random(seed)
     info(s"Using seed $seed")
@@ -33,8 +35,26 @@ class KthGreatestSuite extends FunSuite with Matchers {
       val counts = (0 until (rng.nextInt(10000) + 1)).map(_ => rng.nextInt(Short.MaxValue).toShort).toArray
       val k = rng.nextInt(counts.length)
       val res = KthGreatest.kthGreatest(counts, k)
-      res shouldBe counts.sorted.reverse(k)
+      res.max shouldBe counts.max
+      res.kthGreatest shouldBe counts.sorted.reverse(k)
+      res.numGreaterThanKthGreatest shouldBe counts.count(_ > res.kthGreatest)
     }
+  }
+
+  test("all zero except one") {
+    val counts = Array[Short](50, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    val res = KthGreatest.kthGreatest(counts, 3)
+    res.kthGreatest shouldBe 0
+    res.max shouldBe 50
+    res.numGreaterThanKthGreatest shouldBe 1
+  }
+
+  test("all zero") {
+    val counts = Array[Short](0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    val res = KthGreatest.kthGreatest(counts, 3)
+    res.kthGreatest shouldBe 0
+    res.max shouldBe 0
+    res.numGreaterThanKthGreatest shouldBe 0
   }
 
 }


### PR DESCRIPTION
In the previous implementation, if there were multiple docs with matching hash counts = the kth greatest matching hash count, all of them would be emitted.
For example, if matching hash counts were `1,2,2,2,2,2,3,4`, and `candidates = 3`, it would emit the docs corresponding to any count >= 2. 
Now it will only emit the docs with count > 2 and one of the docs with count = 2.

Also removes some unnecessary repetition from the recall suite.