### PR TITLE
More memory efficient implementation of ElastiknnModel in python client

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- More memory-efficient implementation of Python ElastiknnModel.fit method. Uses an iterator over the vectors instead of a list of the vectors.
+---
 - Renamed parameter `r` in L2Lsh mapping to `w`, which is more appropriate and common for "width".
 - Updates and fixes in the Python client based on usage for ann-benchmarks. Mainly adding/fixing data classes in `elastiknn.api`.
 ---

--- a/client-python/elastiknn/client.py
+++ b/client-python/elastiknn/client.py
@@ -59,7 +59,7 @@ class ElastiknnClient(object):
         }
         return self.es.transport.perform_request("PUT", f"/{index}/_mapping", body=body)
 
-    def index(self, index: str, vec_field: str, vecs: Iterable[Vec.Base], stored_id_field: str, ids: List[str], refresh: bool = False) -> Tuple[int, List[Dict]]:
+    def index(self, index: str, vec_field: str, vecs: Iterable[Vec.Base], stored_id_field: str, ids: Iterable[str], refresh: bool = False) -> Tuple[int, List[Dict]]:
         """Index (i.e. store) the given vectors at the given index and field with the optional ids.
 
         Parameters
@@ -70,8 +70,8 @@ class ElastiknnClient(object):
             Field containing the vector in each document.
         vecs : List of `Vec.Base`
             Vectors that should be indexed.
-        ids : List of strings
-            List of ids associated with the given vectors. Must have same length as vecs.
+        ids : Iterable of strings
+            Ids associated with the given vectors. Should have same length as vecs.
         stored_id_field:
             Field containing the document ID. Uses `store: true` setting as an optimization for faster id-only queries.
         refresh : bool
@@ -84,9 +84,6 @@ class ElastiknnClient(object):
         List of Dicts
             Error responses for the vectors that were not indexed.
         """
-
-        assert len(vecs) == len(ids), \
-            f"List of vecs has length [{len(vecs)}], list of ids has length [{len(ids)}]. The two should be equal."
 
         def gen():
             for vec, _id in zip(vecs, ids):

--- a/examples/ann-benchmarks/readme.md
+++ b/examples/ann-benchmarks/readme.md
@@ -23,9 +23,25 @@ Plot results for a specific dataset:
 python plot.py --dataset glove-100-angular --recompute --count 100 --y-log -o out.png
 ```
 
-When debugging, it's useful to restrict the size of `X_train` and `X_test` in the `run` method in `runner.py`, e.g.
+When debugging, restrict the size of `X_train` and `X_test` in the `run` method in `runner.py`, e.g.
 
 ```
 X_train = numpy.array(D['train'])
 X_test = numpy.array(D['test'][:500])
 ```
+
+When debugging, use a local copy of the elastiknn client.
+
+```
+# Run in the ann-benchmarks project.
+rsync -av --exclude={'venv','build','target','.minio','.git','.idea','.terraform'} ../elastiknn elastiknn
+``` 
+
+```
+# Add these lines to the dockerfile.
+COPY elastiknn /tmp/
+RUN python3 -m pip install -e /tmp/elastiknn/client-python
+```
+
+Run a script that copies Elasticsearch logs into the local filesystem. Useful for inspecting logs of containers that crashed.
+

--- a/examples/ann-benchmarks/slurp-logs.sh
+++ b/examples/ann-benchmarks/slurp-logs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+while true;
+do
+  for c in $(docker ps -q);
+  do
+    echo "$c"
+    mkdir -p /tmp/ann-benchmarks-$c
+    for f in $(docker exec $c ls /var/log/elasticsearch);
+    do
+      docker exec $c cat /var/log/elasticsearch/$f > /tmp/ann-benchmarks-$c/$f
+    done
+  done
+  sleep 1
+done


### PR DESCRIPTION
This uses iterators (iterables ?) to produce the elastiknn vectors lazily instead of keeping them all in memory.
Seems to fix some memory issues I was having with the ann-benchmarks project, where the containers would spike over 10GB of memory and crash.