### PR TITLE
Fix NPE when searching after deleting docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- Fixed null pointer exception which was happening when running queries after deleting some vectors.
+---
 - More memory-efficient implementation of Python ElastiknnModel.fit method. Uses an iterator over the vectors instead of a list of the vectors.
 ---
 - Renamed parameter `r` in L2Lsh mapping to `w`, which is more appropriate and common for "width".
@@ -16,6 +18,7 @@
 ---
 - Switched to less-naive implementation of multiprobe L2 LSH. Specifically, uses algorithm 1 from Qin, et. al. to generate
   perturbation sets lazily at query time instead of generating them exhaustively. This does not use the estimated 
+  
   scoring optimization from that paper.
 - Performance optimizations for approximate queries. Specifically using a faster sorting method to sort the hashes before
   retrieving matching docs from the shard.

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/lucene/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/lucene/ArrayHitCounter.java
@@ -17,6 +17,10 @@ public class ArrayHitCounter implements HitCounter {
         isEmpty = true;
     }
 
+    public static ArrayHitCounter empty() {
+        return new ArrayHitCounter(0);
+    }
+
     @Override
     public void increment(int key, short count) {
         counts[key] += count;
@@ -40,7 +44,7 @@ public class ArrayHitCounter implements HitCounter {
 
     @Override
     public KthGreatest.Result kthGreatest(int k) {
-        return KthGreatest.kthGreatest(counts, k);
+        return KthGreatest.kthGreatest(counts, Math.min(k, counts.length - 1));
     }
 
     @Override

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/lucene/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/lucene/ArrayHitCounter.java
@@ -17,10 +17,6 @@ public class ArrayHitCounter implements HitCounter {
         isEmpty = true;
     }
 
-    public static ArrayHitCounter empty() {
-        return new ArrayHitCounter(0);
-    }
-
     @Override
     public void increment(int key, short count) {
         counts[key] += count;

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/KthGreatest.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/KthGreatest.java
@@ -23,7 +23,7 @@ public class KthGreatest {
      * @param k the desired largest value.
      * @return the kth largest value.
      */
-    public static Result kthGreatest(short[] arr, int k) throws IllegalArgumentException {
+    public static Result kthGreatest(short[] arr, int k) {
         if (arr.length == 0) {
             throw new IllegalArgumentException("Array must be non-empty");
         } else if (k < 0 || k >= arr.length) {

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/KthGreatest.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/KthGreatest.java
@@ -23,7 +23,7 @@ public class KthGreatest {
      * @param k the desired largest value.
      * @return the kth largest value.
      */
-    public static Result kthGreatest(short[] arr, int k) {
+    public static Result kthGreatest(short[] arr, int k) throws IllegalArgumentException {
         if (arr.length == 0) {
             throw new IllegalArgumentException("Array must be non-empty");
         } else if (k < 0 || k >= arr.length) {

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -26,7 +26,6 @@ public class MatchHashesAndScoreQuery extends Query {
     private final int candidates;
     private final IndexReader indexReader;
     private final Function<LeafReaderContext, ScoreFunction> scoreFunctionBuilder;
-    // private final int numDocsInSegment;
 
     public MatchHashesAndScoreQuery(final String field,
                                     final HashAndFreq[] hashAndFrequencies,
@@ -56,7 +55,7 @@ public class MatchHashesAndScoreQuery extends Query {
                 Terms terms = reader.terms(field);
                 // terms seem to be null after deleting docs. https://github.com/alexklibisz/elastiknn/issues/158
                 if (terms == null) {
-                    return ArrayHitCounter.empty();
+                    return new ArrayHitCounter(0);
                 } else {
                     TermsEnum termsEnum = terms.iterator();
                     PostingsEnum docs = null;

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MatchHashesAndScoreQuerySuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MatchHashesAndScoreQuerySuite.scala
@@ -1,16 +1,5 @@
 package com.klibisz.elastiknn.query
 
-//import com.klibisz.elastiknn.mapper.VectorMapper
-//import com.klibisz.elastiknn.models.HashAndFreq
-//import com.klibisz.elastiknn.storage.UnsafeSerialization._
-//import com.klibisz.elastiknn.testing.LuceneSupport
-//import org.apache.lucene.document.{Document, Field, FieldType}
-//import org.apache.lucene.index._
-//import org.apache.lucene.search.{IndexSearcher, MatchHashesAndScoreQuery, TermQuery}
-//import org.scalatest._
-//
-//import scala.collection.mutable.ArrayBuffer
-
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.models.HashAndFreq
 import com.klibisz.elastiknn.storage.UnsafeSerialization._

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MatchHashesAndScoreQuerySuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MatchHashesAndScoreQuerySuite.scala
@@ -1,5 +1,16 @@
 package com.klibisz.elastiknn.query
 
+//import com.klibisz.elastiknn.mapper.VectorMapper
+//import com.klibisz.elastiknn.models.HashAndFreq
+//import com.klibisz.elastiknn.storage.UnsafeSerialization._
+//import com.klibisz.elastiknn.testing.LuceneSupport
+//import org.apache.lucene.document.{Document, Field, FieldType}
+//import org.apache.lucene.index._
+//import org.apache.lucene.search.{IndexSearcher, MatchHashesAndScoreQuery, TermQuery}
+//import org.scalatest._
+//
+//import scala.collection.mutable.ArrayBuffer
+
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.models.HashAndFreq
 import com.klibisz.elastiknn.storage.UnsafeSerialization._
@@ -13,7 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class MatchHashesAndScoreQuerySuite extends FunSuite with Matchers with LuceneSupport {
 
-  val ft = new VectorMapper.FieldType("elastiknn_dense_float_vector")
+  val ft: VectorMapper.FieldType = new VectorMapper.FieldType("elastiknn_dense_float_vector")
 
   test("empty harness") {
     indexAndSearch() { (_: IndexWriter) =>
@@ -91,7 +102,7 @@ class MatchHashesAndScoreQuerySuite extends FunSuite with Matchers with LuceneSu
     }
   }
 
-  test("documents with 0 hashes are not candidates") {
+  test("documents with 0 matches are not candidates") {
     indexAndSearch() { w =>
       for (_ <- 0 until 10) {
         val d = new Document()

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
@@ -1,207 +1,200 @@
 package com.klibisz.elastiknn.query
 
-//import java.util.UUID
-//
-//import com.klibisz.elastiknn.api._
-//import com.klibisz.elastiknn.client.Elastic4sCompatibility._
-//import com.klibisz.elastiknn.testing.{ElasticAsyncClient, SilentMatchers}
-//import com.sksamuel.elastic4s.ElasticDsl._
-//import com.sksamuel.elastic4s.XContentFactory
-//import com.sksamuel.elastic4s.requests.common.RefreshPolicy
-//import org.scalatest.{AsyncFunSpec, Inspectors, Matchers}
-//
-//import scala.concurrent.Future
-//import scala.util.Random
+import java.util.UUID
 
 import com.klibisz.elastiknn.api._
+import com.klibisz.elastiknn.client.Elastic4sCompatibility._
 import com.klibisz.elastiknn.testing.{ElasticAsyncClient, SilentMatchers}
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.XContentFactory
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import org.scalatest.{AsyncFunSpec, Inspectors, Matchers}
 
+import scala.concurrent.Future
 import scala.util.Random
 
 class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspectors with ElasticAsyncClient with SilentMatchers {
 
-//  // https://github.com/alexklibisz/elastiknn/issues/60
-//  describe("Vectors in nested fields") {
-//    implicit val rng: Random = new Random(0)
-//    val index = "issue-60"
-//    val vec = Vec.DenseFloat.random(10)
-//    val mapping = Mapping.DenseFloat(vec.values.length)
-//    val nestedFields = Seq(
-//      "vec",
-//      "foo.vec",
-//      "foo.bar.vec",
-//      "foo.bar.baz.vec"
-//    )
-//
-//    for {
-//      nestedField <- nestedFields
-//    } yield {
-//      val (mappingSource, docSource) = {
-//        val subFields = nestedField.split('.')
-//        val xMapping = XContentFactory.obj()
-//        val xDoc = XContentFactory.obj()
-//        xMapping.startObject("properties")
-//        subFields.init.foreach { f =>
-//          xMapping.startObject(f)
-//          xMapping.startObject("properties")
-//          xDoc.startObject(f)
-//        }
-//        xMapping.rawField(subFields.last, ElasticsearchCodec.mapping(mapping).spaces2)
-//        xDoc.rawField(subFields.last, ElasticsearchCodec.vec(vec).spaces2)
-//        subFields.init.foreach { _ =>
-//          xMapping.endObject()
-//          xMapping.endObject()
-//          xDoc.endObject()
-//        }
-//        xMapping.endObject()
-//        xDoc.endObject()
-//        (xMapping.string(), xDoc.string())
-//      }
-//      it(s"works with nested field: $nestedField") {
-//        for {
-//          _ <- deleteIfExists(index)
-//          _ <- eknn.execute(createIndex(index))
-//          _ <- eknn.execute(putMapping(index).rawSource(mappingSource))
-//          _ <- eknn.execute(indexInto(index).source(docSource).refresh(RefreshPolicy.IMMEDIATE))
-//          res <- eknn.execute(search(index).query(NearestNeighborsQuery.Exact(nestedField, Similarity.L2, vec)))
-//        } yield {
-//          res.result.hits.hits should have length 1
-//          res.result.hits.maxScore shouldBe 1.0
-//        }
-//      }
-//    }
-//  }
-//
-//  // https://github.com/alexklibisz/elastiknn/issues/97
-//  describe("Query with filter on another field") {
-//    implicit val rng: Random = new Random(0)
-//    val indexPrefix = "issue-97"
-//
-//    // Generate a corpus of 100 docs. < 10 of the them have color blue, rest have color red.
-//    val dims = 10
-//    val numBlue = 8
-//    val corpus = (0 until 100).map(i => (s"v$i", Vec.DenseFloat.random(dims), if (i < numBlue) "blue" else "red"))
-//
-//    // Test with multiple mappings/queries.
-//    val queryVec = Vec.DenseFloat.random(dims)
-//    val mappingsAndQueries = Seq(
-//      Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
-//        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-//        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
-//        NearestNeighborsQuery.L2Lsh("vec", 100, vec = queryVec)
-//      ),
-//      Mapping.AngularLsh(dims, 40, 1) -> Seq(
-//        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-//        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
-//        NearestNeighborsQuery.AngularLsh("vec", 100, queryVec)
-//      )
-//    )
-//
-//    for {
-//      (mapping, queries) <- mappingsAndQueries
-//      query: NearestNeighborsQuery <- queries
-//    } it(s"filters with mapping [${mapping}] and query [${query}]") {
-//      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
-//      val rawMapping =
-//        s"""
-//           |{
-//           |  "properties": {
-//           |    "vec": ${ElasticsearchCodec.mapping(mapping).noSpaces},
-//           |    "color": {
-//           |      "type": "keyword"
-//           |    }
-//           |  }
-//           |}
-//           |""".stripMargin
-//      val rawQuery =
-//        s"""
-//           |{
-//           |  "bool": {
-//           |    "filter": [
-//           |      { "term": { "color": "blue" } }
-//           |    ],
-//           |    "must": {
-//           |      "elastiknn_nearest_neighbors": ${ElasticsearchCodec.nearestNeighborsQuery(query).spaces4}
-//           |    }
-//           |  }
-//           |}
-//           |""".stripMargin
-//      for {
-//        _ <- deleteIfExists(index)
-//        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
-//        _ <- eknn.execute(putMapping(index).rawSource(rawMapping))
-//        _ <- Future.traverse(corpus) {
-//          case (id, vec, color) =>
-//            val docSource =
-//              s"""
-//                 |{
-//                 |  "vec": ${ElasticsearchCodec.nospaces(vec)},
-//                 |  "color": "$color"
-//                 |}
-//                 |""".stripMargin
-//            eknn.execute(indexInto(index).id(id).source(docSource))
-//        }
-//        _ <- eknn.execute(refreshIndex(index))
-//        res <- eknn.execute(search(index).rawQuery(rawQuery))
-//      } yield {
-//        res.result.hits.hits should have length numBlue
-//        res.result.hits.hits.map(_.id).toSet shouldBe corpus.filter(_._3 == "blue").map(_._1).toSet
-//      }
-//    }
-//  }
-//
-//  // https://gitter.im/elastiknn/community?at=5f3012df65e829425e70ee31
-//  describe("Sparse bool vectors with unsorted indices") {
-//    implicit val rng: Random = new Random(0)
-//    val indexPrefix = "test-sbv-unsorted"
-//
-//    val dims = 20000
-//    val corpus = Vec.SparseBool.randoms(dims, 100)
-//
-//    val queryVec = {
-//      val sorted = corpus.head
-//      val shuffled = rng.shuffle(sorted.trueIndices.toVector).toArray
-//      sorted.copy(shuffled)
-//    }
-//
-//    // Test with multiple mappings/queries.
-//    val mappingsAndQueries = Seq(
-//      Mapping.SparseBool(dims) -> Seq(
-//        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
-//        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
-//      ),
-//      Mapping.JaccardLsh(dims, 40, 1) -> Seq(
-//        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
-//        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
-//        NearestNeighborsQuery.JaccardLsh("vec", 100, queryVec)
-//      ),
-//      Mapping.HammingLsh(dims, 40, 2) -> Seq(
-//        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
-//        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
-//        NearestNeighborsQuery.HammingLsh("vec", 100, queryVec)
-//      )
-//    )
-//
-//    for {
-//      (mapping, queries) <- mappingsAndQueries
-//      query <- queries
-//    } it(s"finds unsorted sparse bool vecs with mapping [${mapping}] and query [${query}]") {
-//      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
-//      for {
-//        _ <- deleteIfExists(index)
-//        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
-//        _ <- eknn.putMapping(index, "vec", "id", mapping)
-//        _ <- eknn.index(index, "vec", corpus, "id", corpus.indices.map(i => s"v$i"))
-//        _ <- eknn.execute(refreshIndex(index))
-//        res <- eknn.nearestNeighbors(index, query, 5, "id")
-//      } yield {
-//        res.result.maxScore shouldBe 1d
-//        res.result.hits.hits.head.id shouldBe "v0"
-//      }
-//    }
-//  }
+  // https://github.com/alexklibisz/elastiknn/issues/60
+  describe("Vectors in nested fields") {
+    implicit val rng: Random = new Random(0)
+    val index = "issue-60"
+    val vec = Vec.DenseFloat.random(10)
+    val mapping = Mapping.DenseFloat(vec.values.length)
+    val nestedFields = Seq(
+      "vec",
+      "foo.vec",
+      "foo.bar.vec",
+      "foo.bar.baz.vec"
+    )
+
+    for {
+      nestedField <- nestedFields
+    } yield {
+      val (mappingSource, docSource) = {
+        val subFields = nestedField.split('.')
+        val xMapping = XContentFactory.obj()
+        val xDoc = XContentFactory.obj()
+        xMapping.startObject("properties")
+        subFields.init.foreach { f =>
+          xMapping.startObject(f)
+          xMapping.startObject("properties")
+          xDoc.startObject(f)
+        }
+        xMapping.rawField(subFields.last, ElasticsearchCodec.mapping(mapping).spaces2)
+        xDoc.rawField(subFields.last, ElasticsearchCodec.vec(vec).spaces2)
+        subFields.init.foreach { _ =>
+          xMapping.endObject()
+          xMapping.endObject()
+          xDoc.endObject()
+        }
+        xMapping.endObject()
+        xDoc.endObject()
+        (xMapping.string(), xDoc.string())
+      }
+      it(s"works with nested field: $nestedField") {
+        for {
+          _ <- deleteIfExists(index)
+          _ <- eknn.execute(createIndex(index))
+          _ <- eknn.execute(putMapping(index).rawSource(mappingSource))
+          _ <- eknn.execute(indexInto(index).source(docSource).refresh(RefreshPolicy.IMMEDIATE))
+          res <- eknn.execute(search(index).query(NearestNeighborsQuery.Exact(nestedField, Similarity.L2, vec)))
+        } yield {
+          res.result.hits.hits should have length 1
+          res.result.hits.maxScore shouldBe 1.0
+        }
+      }
+    }
+  }
+
+  // https://github.com/alexklibisz/elastiknn/issues/97
+  describe("Query with filter on another field") {
+    implicit val rng: Random = new Random(0)
+    val indexPrefix = "issue-97"
+
+    // Generate a corpus of 100 docs. < 10 of the them have color blue, rest have color red.
+    val dims = 10
+    val numBlue = 8
+    val corpus = (0 until 100).map(i => (s"v$i", Vec.DenseFloat.random(dims), if (i < numBlue) "blue" else "red"))
+
+    // Test with multiple mappings/queries.
+    val queryVec = Vec.DenseFloat.random(dims)
+    val mappingsAndQueries = Seq(
+      Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+        NearestNeighborsQuery.L2Lsh("vec", 100, vec = queryVec)
+      ),
+      Mapping.AngularLsh(dims, 40, 1) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+        NearestNeighborsQuery.AngularLsh("vec", 100, queryVec)
+      )
+    )
+
+    for {
+      (mapping, queries) <- mappingsAndQueries
+      query: NearestNeighborsQuery <- queries
+    } it(s"filters with mapping [${mapping}] and query [${query}]") {
+      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
+      val rawMapping =
+        s"""
+           |{
+           |  "properties": {
+           |    "vec": ${ElasticsearchCodec.mapping(mapping).noSpaces},
+           |    "color": {
+           |      "type": "keyword"
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+      val rawQuery =
+        s"""
+           |{
+           |  "bool": {
+           |    "filter": [
+           |      { "term": { "color": "blue" } }
+           |    ],
+           |    "must": {
+           |      "elastiknn_nearest_neighbors": ${ElasticsearchCodec.nearestNeighborsQuery(query).spaces4}
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+      for {
+        _ <- deleteIfExists(index)
+        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
+        _ <- eknn.execute(putMapping(index).rawSource(rawMapping))
+        _ <- Future.traverse(corpus) {
+          case (id, vec, color) =>
+            val docSource =
+              s"""
+                 |{
+                 |  "vec": ${ElasticsearchCodec.nospaces(vec)},
+                 |  "color": "$color"
+                 |}
+                 |""".stripMargin
+            eknn.execute(indexInto(index).id(id).source(docSource))
+        }
+        _ <- eknn.execute(refreshIndex(index))
+        res <- eknn.execute(search(index).rawQuery(rawQuery))
+      } yield {
+        res.result.hits.hits should have length numBlue
+        res.result.hits.hits.map(_.id).toSet shouldBe corpus.filter(_._3 == "blue").map(_._1).toSet
+      }
+    }
+  }
+
+  // https://gitter.im/elastiknn/community?at=5f3012df65e829425e70ee31
+  describe("Sparse bool vectors with unsorted indices") {
+    implicit val rng: Random = new Random(0)
+    val indexPrefix = "test-sbv-unsorted"
+
+    val dims = 20000
+    val corpus = Vec.SparseBool.randoms(dims, 100)
+
+    val queryVec = {
+      val sorted = corpus.head
+      val shuffled = rng.shuffle(sorted.trueIndices.toVector).toArray
+      sorted.copy(shuffled)
+    }
+
+    // Test with multiple mappings/queries.
+    val mappingsAndQueries = Seq(
+      Mapping.SparseBool(dims) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
+      ),
+      Mapping.JaccardLsh(dims, 40, 1) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
+        NearestNeighborsQuery.JaccardLsh("vec", 100, queryVec)
+      ),
+      Mapping.HammingLsh(dims, 40, 2) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
+        NearestNeighborsQuery.HammingLsh("vec", 100, queryVec)
+      )
+    )
+
+    for {
+      (mapping, queries) <- mappingsAndQueries
+      query <- queries
+    } it(s"finds unsorted sparse bool vecs with mapping [${mapping}] and query [${query}]") {
+      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
+      for {
+        _ <- deleteIfExists(index)
+        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
+        _ <- eknn.putMapping(index, "vec", "id", mapping)
+        _ <- eknn.index(index, "vec", corpus, "id", corpus.indices.map(i => s"v$i"))
+        _ <- eknn.execute(refreshIndex(index))
+        res <- eknn.nearestNeighbors(index, query, 5, "id")
+      } yield {
+        res.result.maxScore shouldBe 1d
+        res.result.hits.hits.head.id shouldBe "v0"
+      }
+    }
+  }
 
   describe("deleting vectors") {
 

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
@@ -1,197 +1,256 @@
 package com.klibisz.elastiknn.query
 
-import java.util.UUID
+//import java.util.UUID
+//
+//import com.klibisz.elastiknn.api._
+//import com.klibisz.elastiknn.client.Elastic4sCompatibility._
+//import com.klibisz.elastiknn.testing.{ElasticAsyncClient, SilentMatchers}
+//import com.sksamuel.elastic4s.ElasticDsl._
+//import com.sksamuel.elastic4s.XContentFactory
+//import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+//import org.scalatest.{AsyncFunSpec, Inspectors, Matchers}
+//
+//import scala.concurrent.Future
+//import scala.util.Random
 
 import com.klibisz.elastiknn.api._
-import com.klibisz.elastiknn.client.Elastic4sCompatibility._
 import com.klibisz.elastiknn.testing.{ElasticAsyncClient, SilentMatchers}
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.XContentFactory
-import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import org.scalatest.{AsyncFunSpec, Inspectors, Matchers}
 
-import scala.concurrent.Future
 import scala.util.Random
 
 class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspectors with ElasticAsyncClient with SilentMatchers {
 
-  // https://github.com/alexklibisz/elastiknn/issues/60
-  describe("Vectors in nested fields") {
-    implicit val rng: Random = new Random(0)
-    val index = "test-queries-nested-fields"
-    val vec = Vec.DenseFloat.random(10)
-    val mapping = Mapping.DenseFloat(vec.values.length)
-    val nestedFields = Seq(
-      "vec",
-      "foo.vec",
-      "foo.bar.vec",
-      "foo.bar.baz.vec"
-    )
+//  // https://github.com/alexklibisz/elastiknn/issues/60
+//  describe("Vectors in nested fields") {
+//    implicit val rng: Random = new Random(0)
+//    val index = "issue-60"
+//    val vec = Vec.DenseFloat.random(10)
+//    val mapping = Mapping.DenseFloat(vec.values.length)
+//    val nestedFields = Seq(
+//      "vec",
+//      "foo.vec",
+//      "foo.bar.vec",
+//      "foo.bar.baz.vec"
+//    )
+//
+//    for {
+//      nestedField <- nestedFields
+//    } yield {
+//      val (mappingSource, docSource) = {
+//        val subFields = nestedField.split('.')
+//        val xMapping = XContentFactory.obj()
+//        val xDoc = XContentFactory.obj()
+//        xMapping.startObject("properties")
+//        subFields.init.foreach { f =>
+//          xMapping.startObject(f)
+//          xMapping.startObject("properties")
+//          xDoc.startObject(f)
+//        }
+//        xMapping.rawField(subFields.last, ElasticsearchCodec.mapping(mapping).spaces2)
+//        xDoc.rawField(subFields.last, ElasticsearchCodec.vec(vec).spaces2)
+//        subFields.init.foreach { _ =>
+//          xMapping.endObject()
+//          xMapping.endObject()
+//          xDoc.endObject()
+//        }
+//        xMapping.endObject()
+//        xDoc.endObject()
+//        (xMapping.string(), xDoc.string())
+//      }
+//      it(s"works with nested field: $nestedField") {
+//        for {
+//          _ <- deleteIfExists(index)
+//          _ <- eknn.execute(createIndex(index))
+//          _ <- eknn.execute(putMapping(index).rawSource(mappingSource))
+//          _ <- eknn.execute(indexInto(index).source(docSource).refresh(RefreshPolicy.IMMEDIATE))
+//          res <- eknn.execute(search(index).query(NearestNeighborsQuery.Exact(nestedField, Similarity.L2, vec)))
+//        } yield {
+//          res.result.hits.hits should have length 1
+//          res.result.hits.maxScore shouldBe 1.0
+//        }
+//      }
+//    }
+//  }
+//
+//  // https://github.com/alexklibisz/elastiknn/issues/97
+//  describe("Query with filter on another field") {
+//    implicit val rng: Random = new Random(0)
+//    val indexPrefix = "issue-97"
+//
+//    // Generate a corpus of 100 docs. < 10 of the them have color blue, rest have color red.
+//    val dims = 10
+//    val numBlue = 8
+//    val corpus = (0 until 100).map(i => (s"v$i", Vec.DenseFloat.random(dims), if (i < numBlue) "blue" else "red"))
+//
+//    // Test with multiple mappings/queries.
+//    val queryVec = Vec.DenseFloat.random(dims)
+//    val mappingsAndQueries = Seq(
+//      Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
+//        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
+//        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+//        NearestNeighborsQuery.L2Lsh("vec", 100, vec = queryVec)
+//      ),
+//      Mapping.AngularLsh(dims, 40, 1) -> Seq(
+//        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
+//        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+//        NearestNeighborsQuery.AngularLsh("vec", 100, queryVec)
+//      )
+//    )
+//
+//    for {
+//      (mapping, queries) <- mappingsAndQueries
+//      query: NearestNeighborsQuery <- queries
+//    } it(s"filters with mapping [${mapping}] and query [${query}]") {
+//      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
+//      val rawMapping =
+//        s"""
+//           |{
+//           |  "properties": {
+//           |    "vec": ${ElasticsearchCodec.mapping(mapping).noSpaces},
+//           |    "color": {
+//           |      "type": "keyword"
+//           |    }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      val rawQuery =
+//        s"""
+//           |{
+//           |  "bool": {
+//           |    "filter": [
+//           |      { "term": { "color": "blue" } }
+//           |    ],
+//           |    "must": {
+//           |      "elastiknn_nearest_neighbors": ${ElasticsearchCodec.nearestNeighborsQuery(query).spaces4}
+//           |    }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      for {
+//        _ <- deleteIfExists(index)
+//        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
+//        _ <- eknn.execute(putMapping(index).rawSource(rawMapping))
+//        _ <- Future.traverse(corpus) {
+//          case (id, vec, color) =>
+//            val docSource =
+//              s"""
+//                 |{
+//                 |  "vec": ${ElasticsearchCodec.nospaces(vec)},
+//                 |  "color": "$color"
+//                 |}
+//                 |""".stripMargin
+//            eknn.execute(indexInto(index).id(id).source(docSource))
+//        }
+//        _ <- eknn.execute(refreshIndex(index))
+//        res <- eknn.execute(search(index).rawQuery(rawQuery))
+//      } yield {
+//        res.result.hits.hits should have length numBlue
+//        res.result.hits.hits.map(_.id).toSet shouldBe corpus.filter(_._3 == "blue").map(_._1).toSet
+//      }
+//    }
+//  }
+//
+//  // https://gitter.im/elastiknn/community?at=5f3012df65e829425e70ee31
+//  describe("Sparse bool vectors with unsorted indices") {
+//    implicit val rng: Random = new Random(0)
+//    val indexPrefix = "test-sbv-unsorted"
+//
+//    val dims = 20000
+//    val corpus = Vec.SparseBool.randoms(dims, 100)
+//
+//    val queryVec = {
+//      val sorted = corpus.head
+//      val shuffled = rng.shuffle(sorted.trueIndices.toVector).toArray
+//      sorted.copy(shuffled)
+//    }
+//
+//    // Test with multiple mappings/queries.
+//    val mappingsAndQueries = Seq(
+//      Mapping.SparseBool(dims) -> Seq(
+//        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
+//        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
+//      ),
+//      Mapping.JaccardLsh(dims, 40, 1) -> Seq(
+//        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
+//        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
+//        NearestNeighborsQuery.JaccardLsh("vec", 100, queryVec)
+//      ),
+//      Mapping.HammingLsh(dims, 40, 2) -> Seq(
+//        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
+//        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
+//        NearestNeighborsQuery.HammingLsh("vec", 100, queryVec)
+//      )
+//    )
+//
+//    for {
+//      (mapping, queries) <- mappingsAndQueries
+//      query <- queries
+//    } it(s"finds unsorted sparse bool vecs with mapping [${mapping}] and query [${query}]") {
+//      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
+//      for {
+//        _ <- deleteIfExists(index)
+//        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
+//        _ <- eknn.putMapping(index, "vec", "id", mapping)
+//        _ <- eknn.index(index, "vec", corpus, "id", corpus.indices.map(i => s"v$i"))
+//        _ <- eknn.execute(refreshIndex(index))
+//        res <- eknn.nearestNeighbors(index, query, 5, "id")
+//      } yield {
+//        res.result.maxScore shouldBe 1d
+//        res.result.hits.hits.head.id shouldBe "v0"
+//      }
+//    }
+//  }
 
-    for {
-      nestedField <- nestedFields
-    } yield {
-      val (mappingSource, docSource) = {
-        val subFields = nestedField.split('.')
-        val xMapping = XContentFactory.obj()
-        val xDoc = XContentFactory.obj()
-        xMapping.startObject("properties")
-        subFields.init.foreach { f =>
-          xMapping.startObject(f)
-          xMapping.startObject("properties")
-          xDoc.startObject(f)
-        }
-        xMapping.rawField(subFields.last, ElasticsearchCodec.mapping(mapping).spaces2)
-        xDoc.rawField(subFields.last, ElasticsearchCodec.vec(vec).spaces2)
-        subFields.init.foreach { _ =>
-          xMapping.endObject()
-          xMapping.endObject()
-          xDoc.endObject()
-        }
-        xMapping.endObject()
-        xDoc.endObject()
-        (xMapping.string(), xDoc.string())
-      }
-      it(s"works with nested field: $nestedField") {
-        for {
-          _ <- deleteIfExists(index)
-          _ <- eknn.execute(createIndex(index))
-          _ <- eknn.execute(putMapping(index).rawSource(mappingSource))
-          _ <- eknn.execute(indexInto(index).source(docSource).refresh(RefreshPolicy.IMMEDIATE))
-          res <- eknn.execute(search(index).query(NearestNeighborsQuery.Exact(nestedField, Similarity.L2, vec)))
-        } yield {
-          res.result.hits.hits should have length 1
-          res.result.hits.maxScore shouldBe 1.0
-        }
-      }
-    }
-  }
+  describe("deleting vectors") {
 
-  // https://github.com/alexklibisz/elastiknn/issues/97
-  describe("Query with filter on another field") {
-    implicit val rng: Random = new Random(0)
-    val indexPrefix = "test-queries-with-filter"
+    // https://github.com/alexklibisz/elastiknn/issues/158
+    it("index, search, delete some, search again") {
 
-    // Generate a corpus of 100 docs. < 10 of the them have color blue, rest have color red.
-    val dims = 10
-    val numBlue = 8
-    val corpus = (0 until 100).map(i => (s"v$i", Vec.DenseFloat.random(dims), if (i < numBlue) "blue" else "red"))
+      implicit val rng: Random = new Random(0)
+      val index = "issue-158"
+      val dims = 100
+      val corpus = Vec.DenseFloat.randoms(dims, 1000)
+      val ids = corpus.indices.map(i => s"v$i")
+      val queryVec = corpus.head
+      val mapping = Mapping.L2Lsh(dims, 40, 4, 2)
+      val query = NearestNeighborsQuery.L2Lsh("vec", 30, 1, queryVec)
 
-    // Test with multiple mappings/queries.
-    val queryVec = Vec.DenseFloat.random(dims)
-    val mappingsAndQueries = Seq(
-      Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
-        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
-        NearestNeighborsQuery.L2Lsh("vec", 100, vec = queryVec)
-      ),
-      Mapping.AngularLsh(dims, 40, 1) -> Seq(
-        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
-        NearestNeighborsQuery.AngularLsh("vec", 100, queryVec)
-      )
-    )
-
-    for {
-      (mapping, queries) <- mappingsAndQueries
-      query: NearestNeighborsQuery <- queries
-    } it(s"filters with mapping [${mapping}] and query [${query}]") {
-      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
-      val rawMapping =
-        s"""
-           |{
-           |  "properties": {
-           |    "vec": ${ElasticsearchCodec.mapping(mapping).noSpaces},
-           |    "color": {
-           |      "type": "keyword"
-           |    }
-           |  }
-           |}
-           |""".stripMargin
-      val rawQuery =
-        s"""
-           |{
-           |  "bool": {
-           |    "filter": [
-           |      { "term": { "color": "blue" } }
-           |    ],
-           |    "must": {
-           |      "elastiknn_nearest_neighbors": ${ElasticsearchCodec.nearestNeighborsQuery(query).spaces4}
-           |    }
-           |  }
-           |}
-           |""".stripMargin
       for {
         _ <- deleteIfExists(index)
-        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
-        _ <- eknn.execute(putMapping(index).rawSource(rawMapping))
-        _ <- Future.traverse(corpus) {
-          case (id, vec, color) =>
-            val docSource =
-              s"""
-                 |{
-                 |  "vec": ${ElasticsearchCodec.nospaces(vec)},
-                 |  "color": "$color"
-                 |}
-                 |""".stripMargin
-            eknn.execute(indexInto(index).id(id).source(docSource))
-        }
-        _ <- eknn.execute(refreshIndex(index))
-        res <- eknn.execute(search(index).rawQuery(rawQuery))
-      } yield {
-        res.result.hits.hits should have length numBlue
-        res.result.hits.hits.map(_.id).toSet shouldBe corpus.filter(_._3 == "blue").map(_._1).toSet
-      }
-    }
-  }
-
-  // https://gitter.im/elastiknn/community?at=5f3012df65e829425e70ee31
-  describe("Sparse bool vectors with unsorted indices") {
-    implicit val rng: Random = new Random(0)
-    val indexPrefix = "test-sbv-unsorted"
-
-    val dims = 20000
-    val corpus = Vec.SparseBool.randoms(dims, 100)
-
-    val queryVec = {
-      val sorted = corpus.head
-      val shuffled = rng.shuffle(sorted.trueIndices.toVector).toArray
-      sorted.copy(shuffled)
-    }
-
-    // Test with multiple mappings/queries.
-    val mappingsAndQueries = Seq(
-      Mapping.SparseBool(dims) -> Seq(
-        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
-        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
-      ),
-      Mapping.JaccardLsh(dims, 40, 1) -> Seq(
-        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
-        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
-        NearestNeighborsQuery.JaccardLsh("vec", 100, queryVec)
-      ),
-      Mapping.HammingLsh(dims, 40, 2) -> Seq(
-        NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, queryVec),
-        NearestNeighborsQuery.Exact("vec", Similarity.Hamming, queryVec),
-        NearestNeighborsQuery.HammingLsh("vec", 100, queryVec)
-      )
-    )
-
-    for {
-      (mapping, queries) <- mappingsAndQueries
-      query <- queries
-    } it(s"finds unsorted sparse bool vecs with mapping [${mapping}] and query [${query}]") {
-      val index = s"$indexPrefix-${UUID.randomUUID.toString}"
-      for {
-        _ <- deleteIfExists(index)
-        _ <- eknn.execute(createIndex(index).shards(1).replicas(1))
+        _ <- eknn.execute(createIndex(index).shards(1).replicas(0))
         _ <- eknn.putMapping(index, "vec", "id", mapping)
-        _ <- eknn.index(index, "vec", corpus, "id", corpus.indices.map(i => s"v$i"))
+        _ <- eknn.index(index, "vec", corpus, "id", ids)
         _ <- eknn.execute(refreshIndex(index))
-        res <- eknn.nearestNeighbors(index, query, 5, "id")
+        _ <- eknn.execute(forceMerge(index).maxSegments(1))
+
+        // Check the count before deleting anything.
+        cnt1 <- eknn.execute(count(index))
+        res1 <- eknn.nearestNeighbors(index, query, 10, "id")
+
+        // Delete the query vector from the index, count, and search again.
+        _ <- eknn.execute(deleteById(index, "v0"))
+        _ <- eknn.execute(refreshIndex(index))
+        cnt2 <- eknn.execute(count(index))
+        res2 <- eknn.nearestNeighbors(index, query, 10, "id")
+
+        // Put the vector back, count, search again.
+        _ <- eknn.index(index, "vec", corpus.take(1), "id", ids.take(1))
+        _ <- eknn.execute(refreshIndex(index))
+        cnt3 <- eknn.execute(count(index))
+        res3 <- eknn.nearestNeighbors(index, query, 10, "id")
+
       } yield {
-        res.result.maxScore shouldBe 1d
-        res.result.hits.hits.head.id shouldBe "v0"
+        cnt1.result.count shouldBe 1000L
+        res1.result.maxScore shouldBe 1d
+        res1.result.hits.hits.head.id shouldBe "v0"
+
+        cnt2.result.count shouldBe 999L
+        res2.result.hits.hits.head.id shouldBe res1.result.hits.hits.tail.head.id
+
+        cnt3.result.count shouldBe 1000L
+        res3.result.hits.hits.head.id shouldBe "v0"
       }
     }
   }


### PR DESCRIPTION
Based on #158 

So far it seems that the solution is:
1. Explicitly handle the possibility of `null` returned when calling `leafReader.terms(field)`.
2. Use `leafReader.numDocs` instead of `indexReader.numDocs` to determine the total number of possible docs.

Added a test for this scenario: index some docs, run a search, delete one doc, run a search, put the doc back, run a search. This passes locally.