### PR TITLE
Fix incorrect counter configuration that was causing array out of bounds errors

### DIFF
--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -4,6 +4,7 @@ import com.klibisz.elastiknn.lucene.ArrayHitCounter;
 import com.klibisz.elastiknn.lucene.HitCounter;
 import com.klibisz.elastiknn.models.HashAndFreq;
 import org.apache.lucene.index.*;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 
 import java.io.IOException;
@@ -59,12 +60,14 @@ public class MatchHashesAndScoreQuery extends Query {
                 } else {
                     TermsEnum termsEnum = terms.iterator();
                     PostingsEnum docs = null;
-                    HitCounter counter = new ArrayHitCounter(reader.numDocs());
+                    HitCounter counter = new ArrayHitCounter(reader.maxDoc());
+                    // TODO: Is this the right place to use the live docs bitset to check for deleted docs?
+                    // Bits liveDocs = reader.getLiveDocs();
                     for (HashAndFreq hac : hashAndFrequencies) {
                         if (termsEnum.seekExact(new BytesRef(hac.getHash()))) {
                             docs = termsEnum.postings(docs, PostingsEnum.NONE);
-                            for (int i = 0; i < docs.cost(); i++) {
-                                counter.increment(docs.nextDoc(), (short) Math.min(hac.getFreq(), docs.freq()));
+                            while (docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                                counter.increment(docs.docID(), (short) Math.min(hac.getFreq(), docs.freq()));
                             }
                         }
                     }

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -4,7 +4,6 @@ import com.klibisz.elastiknn.lucene.ArrayHitCounter;
 import com.klibisz.elastiknn.lucene.HitCounter;
 import com.klibisz.elastiknn.models.HashAndFreq;
 import org.apache.lucene.index.*;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 
 import java.io.IOException;


### PR DESCRIPTION
Related to #158 

Make the hit counter allocate `reader.maxDocs` instead of `reader.numDocs`, because `reader.numDocs` gets decreased when docs get deleted, even though the largest docId will still be the same.

Also made the testing a bit more robust. 