### PR TITLE
Simplifying some query internals

### DIFF
--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -1,4 +1,4 @@
-package com.klibisz.elastiknn.lucene;
+package com.klibisz.elastiknn.search;
 
 import org.apache.lucene.search.KthGreatest;
 
@@ -11,16 +11,27 @@ public class ArrayHitCounter implements HitCounter {
 
     private final short[] counts;
     private boolean isEmpty;
+    private int numHits;
+    private int minKey;
+    private int maxKey;
 
-    public ArrayHitCounter(int maxDocs) {
-        counts = new short[maxDocs];
+    public ArrayHitCounter(int capacity) {
+        counts = new short[capacity];
         isEmpty = true;
+        numHits = 0;
+        minKey = capacity;
+        maxKey = 0;
     }
 
     @Override
     public void increment(int key, short count) {
+        if (counts[key] == 0) {
+            isEmpty = false;
+            numHits++;
+            minKey = Math.min(key, minKey);
+            maxKey = Math.max(key, maxKey);
+        }
         counts[key] += count;
-        isEmpty = false;
     }
 
     @Override
@@ -35,7 +46,22 @@ public class ArrayHitCounter implements HitCounter {
 
     @Override
     public int numHits() {
+        return numHits;
+    }
+
+    @Override
+    public int capacity() {
         return counts.length;
+    }
+
+    @Override
+    public int minKey() {
+        return minKey;
+    }
+
+    @Override
+    public int maxKey() {
+        return maxKey;
     }
 
     @Override
@@ -43,31 +69,4 @@ public class ArrayHitCounter implements HitCounter {
         return KthGreatest.kthGreatest(counts, Math.min(k, counts.length - 1));
     }
 
-    @Override
-    public Iterator iterator() {
-        return new Iterator() {
-
-            private int i = -1;
-
-            @Override
-            public void advance() {
-                i++;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return i + 1 < counts.length;
-            }
-
-            @Override
-            public int docID() {
-                return i;
-            }
-
-            @Override
-            public int count() {
-                return counts[i];
-            }
-        };
-    }
 }

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -10,14 +10,12 @@ import org.apache.lucene.search.KthGreatest;
 public class ArrayHitCounter implements HitCounter {
 
     private final short[] counts;
-    private boolean isEmpty;
     private int numHits;
     private int minKey;
     private int maxKey;
 
     public ArrayHitCounter(int capacity) {
         counts = new short[capacity];
-        isEmpty = true;
         numHits = 0;
         minKey = capacity;
         maxKey = 0;
@@ -26,7 +24,6 @@ public class ArrayHitCounter implements HitCounter {
     @Override
     public void increment(int key, short count) {
         if (counts[key] == 0) {
-            isEmpty = false;
             numHits++;
             minKey = Math.min(key, minKey);
             maxKey = Math.max(key, maxKey);
@@ -41,7 +38,7 @@ public class ArrayHitCounter implements HitCounter {
 
     @Override
     public boolean isEmpty() {
-        return isEmpty;
+        return numHits > 0;
     }
 
     @Override

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -31,7 +31,12 @@ public class ArrayHitCounter implements HitCounter {
             minKey = Math.min(key, minKey);
             maxKey = Math.max(key, maxKey);
         }
-        counts[key] += count;
+        counts[key] += count;  // Important to be after the above.
+    }
+
+    @Override
+    public void increment(int key, int count) {
+        increment(key, (short) count);
     }
 
     @Override

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -38,7 +38,7 @@ public class ArrayHitCounter implements HitCounter {
 
     @Override
     public boolean isEmpty() {
-        return numHits > 0;
+        return numHits == 0;
     }
 
     @Override

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/HitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/HitCounter.java
@@ -1,4 +1,4 @@
-package com.klibisz.elastiknn.lucene;
+package com.klibisz.elastiknn.search;
 
 import org.apache.lucene.search.KthGreatest;
 
@@ -15,14 +15,13 @@ public interface HitCounter {
 
     int numHits();
 
+    int capacity();
+
+    int minKey();
+
+    int maxKey();
+
     KthGreatest.Result kthGreatest(int k);
 
-    interface Iterator {
-        void advance();
-        boolean hasNext();
-        int docID();
-        int count();
-    }
 
-    Iterator iterator();
 }

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/HitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/HitCounter.java
@@ -9,6 +9,8 @@ public interface HitCounter {
 
     void increment(int key, short count);
 
+    void increment(int key, int count);
+
     boolean isEmpty();
 
     short get(int key);
@@ -22,6 +24,5 @@ public interface HitCounter {
     int maxKey();
 
     KthGreatest.Result kthGreatest(int k);
-
 
 }

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -66,7 +66,7 @@ public class MatchHashesAndScoreQuery extends Query {
                         if (termsEnum.seekExact(new BytesRef(hac.getHash()))) {
                             docs = termsEnum.postings(docs, PostingsEnum.NONE);
                             while (docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                                counter.increment(docs.docID(), (short) Math.min(hac.getFreq(), docs.freq()));
+                                counter.increment(docs.docID(), Math.min(hac.getFreq(), docs.freq()));
                             }
                         }
                     }
@@ -100,7 +100,7 @@ public class MatchHashesAndScoreQuery extends Query {
                             // Ensure that docs with count = kgr.kthGreatest are only emitted when there are fewer
                             // than `candidates` docs with count > kgr.kthGreatest.
                             while (true) {
-                                if (numEmitted == candidates || docId + 1 == counter.capacity()) {
+                                if (numEmitted == candidates || docId + 1 > counter.maxKey()) {
                                     docId = DocIdSetIterator.NO_MORE_DOCS;
                                     return docID();
                                 } else {

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -1,7 +1,7 @@
 package org.apache.lucene.search;
 
-import com.klibisz.elastiknn.lucene.ArrayHitCounter;
-import com.klibisz.elastiknn.lucene.HitCounter;
+import com.klibisz.elastiknn.search.ArrayHitCounter;
+import com.klibisz.elastiknn.search.HitCounter;
 import com.klibisz.elastiknn.models.HashAndFreq;
 import org.apache.lucene.index.*;
 import org.apache.lucene.util.BytesRef;
@@ -83,9 +83,7 @@ public class MatchHashesAndScoreQuery extends Query {
                     // Return an iterator over the doc ids >= the min candidate count.
                     return new DocIdSetIterator() {
 
-                        private int docId = -1;
-
-                        private final HitCounter.Iterator iterator = counter.iterator();
+                        private int docId = counter.minKey() - 1;
 
                         // Track the number of ids emitted, and the number of ids with count = kgr.kthGreatest emitted.
                         private int numEmitted = 0;
@@ -102,23 +100,21 @@ public class MatchHashesAndScoreQuery extends Query {
                             // Ensure that docs with count = kgr.kthGreatest are only emitted when there are fewer
                             // than `candidates` docs with count > kgr.kthGreatest.
                             while (true) {
-                                if (numEmitted == candidates || !iterator.hasNext()) {
+                                if (numEmitted == candidates || docId + 1 == counter.capacity()) {
                                     docId = DocIdSetIterator.NO_MORE_DOCS;
                                     return docID();
-                                }
-                                iterator.advance();
-                                if (iterator.count() > kgr.kthGreatest) {
-                                    docId = iterator.docID();
-                                    numEmitted++;
-                                    return docID();
-                                } else if (iterator.count() == kgr.kthGreatest && numEq < candidates - kgr.numGreaterThan) {
-                                    docId = iterator.docID();
-                                    numEq++;
-                                    numEmitted++;
-                                    return docID();
+                                } else {
+                                    docId++;
+                                    if (counter.get(docId) > kgr.kthGreatest) {
+                                        numEmitted++;
+                                        return docID();
+                                    } else if (counter.get(docId) == kgr.kthGreatest && numEq < candidates - kgr.numGreaterThan) {
+                                        numEq++;
+                                        numEmitted++;
+                                        return docID();
+                                    }
                                 }
                             }
-
                         }
 
                         @Override

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
@@ -214,7 +214,7 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
       val (index, vecField, idField, dims) = ("issue-158", "vec", "id", 100)
       val corpus = Vec.DenseFloat.randoms(dims, 1000)
       val ids = corpus.indices.map(i => s"v$i")
-      val mapping = Mapping.L2Lsh(dims, 40, 4, 2)
+      val mapping = Mapping.L2Lsh(dims, 50, 1, 2)
       val query = NearestNeighborsQuery.L2Lsh(vecField, 30, 1)
 
       def searchDeleteSearchReplace(): Future[Assertion] = {
@@ -247,7 +247,7 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
 
           // Search again for the same original vector.
           s3 <- eknn.nearestNeighbors(index, query.withVec(vec), 10, idField)
-          _ = s3.result.hits.hits.map(_.id).toSet shouldBe s1.result.hits.hits.map(_.id).toSet
+          _ = s3.result.hits.hits.map(_.id).sorted shouldBe s1.result.hits.hits.map(_.id).sorted
 
         } yield Assertions.succeed
       }
@@ -260,10 +260,10 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
         _ <- eknn.execute(refreshIndex(index))
 
         _ <- searchDeleteSearchReplace()
-//        _ <- searchDeleteSearchReplace()
-//        _ <- searchDeleteSearchReplace()
-//        _ <- searchDeleteSearchReplace()
-//        _ <- searchDeleteSearchReplace()
+        _ <- searchDeleteSearchReplace()
+        _ <- searchDeleteSearchReplace()
+        _ <- searchDeleteSearchReplace()
+        _ <- searchDeleteSearchReplace()
 
       } yield Assertions.succeed
     }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
@@ -226,7 +226,7 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
 
           // Search for the randomly-picked vector. It should be its own best match.
           s1 <- eknn.nearestNeighbors(index, query.withVec(vec), 10, idField)
-          _ <- s1.result.hits.hits.headOption.map(_.id) shouldBe Some(id)
+          _ = s1.result.hits.hits.headOption.map(_.id) shouldBe Some(id)
 
           // Delete the top five vectors.
           deletedIdxs = s1.result.hits.hits.take(5).map(_.id.drop(1).toInt).toSeq
@@ -260,10 +260,10 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
         _ <- eknn.execute(refreshIndex(index))
 
         _ <- searchDeleteSearchReplace()
-        _ <- searchDeleteSearchReplace()
-        _ <- searchDeleteSearchReplace()
-        _ <- searchDeleteSearchReplace()
-        _ <- searchDeleteSearchReplace()
+//        _ <- searchDeleteSearchReplace()
+//        _ <- searchDeleteSearchReplace()
+//        _ <- searchDeleteSearchReplace()
+//        _ <- searchDeleteSearchReplace()
 
       } yield Assertions.succeed
     }


### PR DESCRIPTION
- HitCounter tracks the range of docIds which have hits (i.e. the min docId with hits and the max).
- DocIdSetIterator only iterates over this range. Previously iterated over all docIds.
- Had to slightly tweak the "deleting vectors" test. It's tricky to explain, but because the test had a mapping with a high value for `k`, the original query had a min candidate count of 0. After deleting some docs and re-inserting them to a new segment, four of the docs that were returned for the original query were no longer being returned because they still had a count of zero, but this time there was only one other non-zero doc in the segment, so those four docs were not being accessed.