### PR TITLE
Some tweaks to benchmarks and python client for faster benchmarking

### DIFF
--- a/.esopts
+++ b/.esopts
@@ -1,3 +1,4 @@
 -Dtests.heap.size=4G
 -Dtests.es.indices.query.bool.max_clause_count=4096
 -Dtests.es.node.processors=1
+-Dtests.es.thread_pool.search.size=1

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+- Tweaks to the Python client:
+  - Removed threadpool from python `ElastiknnModel`. There's a non-trivial cost to using this, and the benchmarking code that uses this client is already single-threaded by design.
+  - Added method `set_query_params` to python `ElastiknnModel`. This lets you update the query parameters once instead of doing it on every call to the `kneighbors` method. 
+  - Using `filter_path` parameter in python `es.search()` method calls. This seems to add about 10 queries/sec. I guess there's some non-negligible cost to how the Elasticsearch python library parses JSON responses?
+---
 - Added optional `limit` parameter to all Lsh queries. For now I'm leaving it undocumented. I'm not 100% sure it's
 a great idea. 
 ---

--- a/client-python/elastiknn/client.py
+++ b/client-python/elastiknn/client.py
@@ -125,6 +125,6 @@ class ElastiknnClient(object):
         if fetch_source:
             return self.es.search(index, body=body, size=k)
         else:
-
             return self.es.search(index, body=body, size=k, _source=fetch_source, docvalue_fields=stored_id_field,
-                                  stored_fields="_none_")
+                                  stored_fields="_none_",
+                                  filter_path=[f'hits.hits.fields.{stored_id_field}', 'hits.hits._score'])

--- a/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/LocalBenchmark.scala
+++ b/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/LocalBenchmark.scala
@@ -12,13 +12,12 @@ object LocalBenchmark extends App {
 
   private val experiments = Seq(
     Experiment(
-      Dataset.AnnbSift,
-      Mapping.DenseFloat(Dataset.AnnbSift.dims),
+      Dataset.AnnbFashionMnist,
+      Mapping.DenseFloat(Dataset.AnnbFashionMnist.dims),
       NearestNeighborsQuery.Exact(field, Similarity.L2),
-      Mapping.L2Lsh(Dataset.AnnbSift.dims, 50, 4, 1),
+      Mapping.L2Lsh(Dataset.AnnbFashionMnist.dims, 50, 4, 6),
       Seq(
-//        Query(NearestNeighborsQuery.L2Lsh(field, 1000, 4), k),
-        Query(NearestNeighborsQuery.L2Lsh(field, 10000, 9, limit = 0.5f), k)
+        Query(NearestNeighborsQuery.L2Lsh(field, 1000, 3), k)
       )
     )
   )
@@ -37,7 +36,7 @@ object LocalBenchmark extends App {
             resultsPrefix = "results",
             bucket = bucket,
             s3Url = Some(s3Url),
-            maxQueries = 1000
+            maxQueries = 10000
           ))
       } yield ()
     }

--- a/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/SearchClient.scala
+++ b/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/SearchClient.scala
@@ -98,7 +98,7 @@ object SearchClient {
                   for {
                     (dur, res) <- ZIO.fromFuture(_ => client.nearestNeighbors(index, query, k, "id")).timed
                     _ <- if (i % 100 == 0) log.debug(s"Completed query [$i] in [$index] in [${dur.toMillis}] ms") else ZIO.succeed(())
-                  } yield QueryResult(res.result.hits.hits.map(_.score), res.result.took)
+                  } yield QueryResult(res.result.hits.hits.map(_.score), dur.toMillis)
               }
             }
 


### PR DESCRIPTION
- Removed threadpool from python `ElastiknnModel`. There's a non-trivial cost to using this, and the benchmarking code that uses this client is already single-threaded by design.
- Added method `set_query_params` to python `ElastiknnModel`. This lets you update the query parameters once instead of doing it on every call to the `kneighbors` method.
- Using `filter_path` parameter in python `es.search()` method calls. This seems to add about 10 queries/sec. I guess there's some non-negligible cost to how the Elasticsearch python library parses JSON responses?
- Switched to using the recorded time instead of the Elasticsearch response `took` time in Scala benchmarks.