### PR TITLE
Shorthand JSON format for vectors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+- Introduces a shorthand alternative format for dense and sparse vectors that makes it easier to work with ES-connectors that don't allow nested docs.
+  - Dense vectors can be represented as a simple array: `{ "vec": [0.1, 0.2, 0.3, ...] }` is equivalent to `{ "vec": { "values": [0.1, 0.2, 0.3] }}`.
+  - Sparse vectors can be represented as an array where the first element is the array of true indices, and the second is the number of total indices: `{"vec": [[1, 3, 5, ...], 100] }` is equivalent to `{ "vec": { "true_indices": [1,3,5,...], "total_indices": 100 }}`
+---
 - No longer caching the mapping for the field being queried. Instead, using the internal mapper service to retrieve the mapping. 
 ---
 - **Breaking internal change - you should re-index your vectors when moving to this version**

--- a/docs/pages/api.md
+++ b/docs/pages/api.md
@@ -16,6 +16,67 @@ Once you've [installed Elastiknn](/installation/), you can use the REST API just
 1. TOC
 {:toc}
 
+## Vectors
+
+You need to specify vectors when indexing documents and when running queries with a literal query vector. 
+In both cases you use the same JSON structure to define vectors. 
+Each vector also has a shorthand alternative, which can be convenient when using tools that don't support nested documents.
+The examples below show the indexing case; the query case will be covered later.
+
+### elastiknn_dense_float_vector
+
+This assumes you've defined a mapping where `my_vec` has type `elastiknn_dense_float_vector`.
+
+```json
+POST /my-index/_doc
+{
+    "my_vec": {
+        "values": [0.1, 0.2, 0.3, ...]    # 1
+    }
+}
+```
+
+```json
+POST /my-index/_doc
+{
+    "my_vec": [0.1, 0.2, 0.3, ...]        # 2
+}
+
+```
+
+|#|Description|
+|:--|:--|
+|1|JSON list of all floating point values in your vector. The length should match the `dims` in your mapping.|
+|2|Shorthand alternative to #1.|
+
+### elastiknn_sparse_bool_vector
+
+This assumes you've defined a mapping where `my_vec` has type `elastiknn_sparse_bool_vector`.
+
+```json
+POST /my-index/_doc
+{
+    "my_vec": {
+       "true_indices": [1, 3, 5, ...],   # 1
+       "total_indices": 100,             # 2
+    }
+}
+```
+
+```json
+POST /my-index/_doc
+{
+    "my_vec": [[1, 3, 5, ...], 100]      # 3
+}
+
+```
+
+|#|Description|
+|:--|:--|
+|1|JSON list of the indices which are `true` in your vector.|
+|2|The total number of indices in your vector. This should match the `dims` in your mapping.|
+|3|Shorthand alternative to #1 and #2. A two-item list where the first item is the `true_indices` and the second is the `total_indices`.|
+
 ## Mappings
 
 Before indexing vectors, you first define a mapping specifying a vector datatype, an indexing model, and the model's parameters. 
@@ -350,51 +411,7 @@ PUT /my-index/_mapping
 |4|Similarity. Supports angular, l1, and l2|
 |5|The number of top indices to pick.|
 |6|Whether or not to repeat the indices proportionally to their rank. See the notes on repeating above.|
-  
 
-## Vectors
-
-You need to specify vectors in your REST requests when indexing documents containing a vector and when running queries
-with a literal query vector. 
-In both cases you use the same JSON structure to define vectors. 
-The examples below show the indexing case; the query case will be covered later.
-
-### elastiknn_sparse_bool_vector
-
-This assumes you've defined a mapping where `my_vec` has type `elastiknn_sparse_bool_vector`.
-
-```json
-POST /my-index/_doc
-{
-    "my_vec": {
-       "true_indices": [1, 3, 5, ...],   # 1
-       "total_indices": 100,             # 2
-    }
-}
-
-```
-
-|#|Description|
-|:--|:--|
-|1|JSON list of the indices which are `true` in your vector.|
-|2|The total number of indices in your vector. This should match the `dims` in your mapping.|
-
-### elastiknn_dense_float_vector
-
-This assumes you've defined a mapping where `my_vec` has type `elastiknn_dense_float_vector`.
-
-```json
-POST /my-index/_doc
-{
-    "my_vec": {
-        "values": [0.1, 0.2, 0.3, ...]    # 1
-    }
-}
-```
-
-|#|Description|
-|:--|:--|
-|1|JSON list of all floating point values in your vector. The length should match the `dims` in your mapping.|
 
 ## Nearest Neighbor Queries
 

--- a/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/ElasticsearchCodec.scala
+++ b/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/ElasticsearchCodec.scala
@@ -65,7 +65,7 @@ object ElasticsearchCodec { esc =>
   private implicit def intToJson(i: Int): Json = Json.fromInt(i)
   private implicit def strToJson(s: String): Json = Json.fromString(s)
   private implicit class EitherSyntax[+L1, +R1](either: Either[L1, R1]) {
-    def orElse[L2 >: L1, R2 >: R1](other: Either[L2, R2]): Either[L2, R2] = if (either.isRight) either else other
+    def orElse[L2 >: L1, R2 >: R1](other: => Either[L2, R2]): Either[L2, R2] = if (either.isRight) either else other
   }
   private implicit class JsonSyntax(j: Json) {
     def ++(other: Json): Json = j.deepMerge(other)
@@ -108,12 +108,23 @@ object ElasticsearchCodec { esc =>
     }
   }
 
-  implicit val denseFloatVector: ESC[Vec.DenseFloat] = ElasticsearchCodec(deriveCodec)
-  implicit val indexedVector: ESC[Vec.Indexed] = ElasticsearchCodec(deriveCodec)
+  implicit val denseFloatVector: ESC[Vec.DenseFloat] = {
+    val derivedCodec: ESC[Vec.DenseFloat] = ElasticsearchCodec(deriveCodec)
+    val shortHandDecoder = new Decoder[Vec.DenseFloat] {
+      override def apply(c: HCursor): Result[Vec.DenseFloat] = c.as[Array[Float]].map(Vec.DenseFloat(_))
+    }
+    new ESC[Vec.DenseFloat] {
+      override def apply(c: HCursor): Result[Vec.DenseFloat] = {
+        derivedCodec(c).orElse(shortHandDecoder(c))
+      }
+      override def apply(a: Vec.DenseFloat): Json = derivedCodec(a)
+    }
+  }
   implicit val sparseBoolVector: ESC[Vec.SparseBool] = {
     implicit val cfg: Configuration = Configuration.default.withSnakeCaseMemberNames
     ElasticsearchCodec(deriveConfiguredCodec)
   }
+  implicit val indexedVector: ESC[Vec.Indexed] = ElasticsearchCodec(deriveCodec)
   implicit val emptyVec: ESC[Vec.Empty] = {
     implicit val cfg: Configuration = Configuration.default.withStrictDecoding
     ElasticsearchCodec(deriveConfiguredCodec)

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/utils/CirceUtils.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/utils/CirceUtils.scala
@@ -8,24 +8,27 @@ import scala.collection.JavaConverters._
 
 trait CirceUtils {
 
-  // Most of the Elasticsearch Json inputs are available as Maps.
-  // This encoder converts the map to a Json so it can then be parsed into case classes.
+  private def encodeAny(a: Any): Json = a match {
+    case s: lang.String  => Json.fromString(s)
+    case l: lang.Long    => Json.fromLong(l)
+    case i: lang.Integer => Json.fromInt(i)
+    case d: lang.Double  => Json.fromDoubleOrNull(d)
+    case f: lang.Float   => Json.fromFloatOrNull(f)
+    case b: lang.Boolean => Json.fromBoolean(b)
+    case l: util.List[_] => Json.fromValues(l.asScala.map(encodeAny))
+    case m: util.Map[_, _] =>
+      val iterable = m.asScala.map(x => x._1.toString -> encodeAny(x._2))
+      Json.fromJsonObject(JsonObject.fromIterable(iterable))
+    case null  => null
+    case other => throw new RuntimeException(s"Couldn't encode object $other to Json")
+  }
+
   implicit def javaMapEncoder: Encoder[util.Map[String, Object]] = new Encoder[util.Map[String, Object]] {
-    private def encodeAny(a: Any): Json = a match {
-      case s: lang.String  => Json.fromString(s)
-      case l: lang.Long    => Json.fromLong(l)
-      case i: lang.Integer => Json.fromInt(i)
-      case d: lang.Double  => Json.fromDoubleOrNull(d)
-      case f: lang.Float   => Json.fromFloatOrNull(f)
-      case b: lang.Boolean => Json.fromBoolean(b)
-      case l: util.List[_] => Json.fromValues(l.asScala.map(encodeAny))
-      case m: util.Map[_, _] =>
-        val iterable = m.asScala.map(x => x._1.toString -> encodeAny(x._2))
-        Json.fromJsonObject(JsonObject.fromIterable(iterable))
-      case null  => null
-      case other => throw new RuntimeException(s"Couldn't encode object $other to Json")
-    }
     override def apply(a: util.Map[String, Object]): Json = encodeAny(a)
+  }
+
+  implicit def javaListEncoder: Encoder[util.List[Object]] = new Encoder[util.List[Object]] {
+    override def apply(l: util.List[Object]): Json = Json.fromValues(l.asScala.map(encodeAny))
   }
 
 }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
@@ -57,6 +57,8 @@ class ElasticsearchCodecSuite extends FunSuite with Matchers {
 
     "[0.1, 1, 11]" shouldDecodeTo [Vec] Vec.DenseFloat(Array(0.1f, 1f, 11f))
 
+    "[[1, 3, 9, 11], 33]" shouldDecodeTo [Vec] Vec.SparseBool(Array(1, 3, 9, 11), 33)
+
   }
 
   test("vectors w/ invalid contents") {

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
@@ -54,6 +54,9 @@ class ElasticsearchCodecSuite extends FunSuite with Matchers {
       |  "field": "vec"
       |}
       |""".stripMargin shouldDecodeTo [Vec] Vec.Indexed("foo", "abc", "vec")
+
+    "[0.1, 1, 11]" shouldDecodeTo [Vec] Vec.DenseFloat(Array(0.1f, 1f, 11f))
+
   }
 
   test("vectors w/ invalid contents") {

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/mapper/VectorMapperSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/mapper/VectorMapperSuite.scala
@@ -1,163 +1,195 @@
 package com.klibisz.elastiknn.mapper
 
-import java.util.UUID
+//import java.util.UUID
+//
+//import com.klibisz.elastiknn.api.{ElasticsearchCodec, Mapping, Vec}
+//import com.klibisz.elastiknn.testing.{Elastic4sMatchers, ElasticAsyncClient}
+//import com.sksamuel.elastic4s.ElasticDsl._
+//import com.sksamuel.elastic4s.requests.get.GetResponse
+//import com.sksamuel.elastic4s.requests.indexes.IndexRequest
+//import com.sksamuel.elastic4s.{Indexes, Response}
+//import io.circe.parser.parse
+//import io.circe.{Json, JsonObject}
+//import io.circe.syntax._
+//import org.scalatest._
+//
+//import scala.concurrent.Future
+//import scala.util.Random
 
-import com.klibisz.elastiknn.api.{ElasticsearchCodec, Mapping, Vec}
+import com.klibisz.elastiknn.api.{Mapping, Vec}
 import com.klibisz.elastiknn.testing.{Elastic4sMatchers, ElasticAsyncClient}
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.get.GetResponse
-import com.sksamuel.elastic4s.{Indexes, Response}
-import io.circe.parser.parse
-import io.circe.{Json, JsonObject}
+import com.sksamuel.elastic4s.requests.indexes.IndexRequest
+import io.circe.syntax._
 import org.scalatest._
 
-import scala.concurrent.Future
 import scala.util.Random
 
 class VectorMapperSuite extends AsyncFunSuite with Matchers with Inspectors with Elastic4sMatchers with ElasticAsyncClient {
 
   implicit val rng: Random = new Random(0)
 
-  test("create index and put mapping") {
-    val index = s"test-${UUID.randomUUID()}"
-    val storedIdField = "id"
-    val mappings: Seq[(String, Mapping)] = Seq(
-      ("vec_spv", Mapping.SparseBool(100)),
-      ("vec_dfv", Mapping.DenseFloat(100)),
-      ("vec_spix", Mapping.SparseIndexed(100)),
-      ("vec_jcdlsh", Mapping.JaccardLsh(100, 65, 1))
-    )
+//  test("create index and put mapping") {
+//    val index = s"test-${UUID.randomUUID()}"
+//    val storedIdField = "id"
+//    val mappings: Seq[(String, Mapping)] = Seq(
+//      ("vec_spv", Mapping.SparseBool(100)),
+//      ("vec_dfv", Mapping.DenseFloat(100)),
+//      ("vec_spix", Mapping.SparseIndexed(100)),
+//      ("vec_jcdlsh", Mapping.JaccardLsh(100, 65, 1))
+//    )
+//    for {
+//      createIndexRes <- eknn.execute(createIndex(index))
+//      _ = createIndexRes.shouldBeSuccess
+//
+//      putMappingReqs = mappings.map {
+//        case (vecField, mapping) => eknn.putMapping(index, vecField, storedIdField, mapping)
+//      }
+//      _ <- Future.sequence(putMappingReqs)
+//
+//      getMappingReqs = mappings.map {
+//        case (fieldName, _) => eknn.execute(getMapping(Indexes(index), fieldName))
+//      }
+//      getMappingRes <- Future.sequence(getMappingReqs)
+//    } yield
+//      forAll(mappings.zip(getMappingRes)) {
+//        case ((fieldName, mapping), res) =>
+//          // Just check the JSON directly. Example structure:
+//          // {
+//          //  "test-226cf173-38d9-40e3-8c3d-3aabccd182ae": {
+//          //    "mappings": {
+//          //      "vec_spv": {
+//          //        "full_name": "vec_spv",
+//          //        "mapping": {
+//          //          "vec_spv": {
+//          //            "type": "elastiknn_sparse_bool_vector",
+//          //            "elastiknn": {
+//          //              "dims": 100
+//          //            }
+//          //          }
+//          //        }
+//          //      }
+//          //    }
+//          //  }
+//          //}
+//
+//          res.body shouldBe defined
+//          val json = parse(res.body.get)
+//          json shouldBe 'right
+//
+//          val encoded = ElasticsearchCodec.encode(mapping)
+//
+//          val mappingJsonOpt: Option[JsonObject] = for {
+//            x <- json.toOption
+//            x <- x.findAllByKey(index).headOption
+//            x <- x.findAllByKey("mappings").headOption
+//            x <- x.findAllByKey(fieldName).headOption
+//            x <- x.findAllByKey("mapping").headOption
+//            x <- x.findAllByKey(fieldName).headOption
+//            x <- x.asObject
+//            y <- encoded.asObject
+//            // The returned mapping might contain some more items, like similarity, so filter them out.
+//          } yield x.filterKeys(y.keys.toSet.contains)
+//
+//          mappingJsonOpt shouldBe encoded.asObject
+//      }
+//
+//  }
+//
+//  test("store and read vectors") {
+//    val vecField = "vec"
+//    val storedIdField = "id"
+//    val (dims, n) = (100, 10)
+//    def ids: Seq[String] = (0 until n).map(_ => UUID.randomUUID().toString)
+//    val inputs: Seq[(String, Mapping, Vector[Vec], Seq[String])] = Seq(
+//      // (index, mapping, random vectors, vector ids
+//      (s"test-${UUID.randomUUID()}", Mapping.SparseBool(dims), Vec.SparseBool.randoms(dims, n), ids),
+//      (s"test-${UUID.randomUUID()}", Mapping.DenseFloat(dims), Vec.DenseFloat.randoms(dims, n), ids),
+//      (s"test-${UUID.randomUUID()}", Mapping.SparseIndexed(dims), Vec.SparseBool.randoms(dims, n), ids),
+//      (s"test-${UUID.randomUUID()}", Mapping.JaccardLsh(dims, 65, 1), Vec.SparseBool.randoms(dims, n), ids)
+//    )
+//
+//    for {
+//      _ <- Future.successful(())
+//
+//      putMappingReqs = inputs.map {
+//        case (indexName, mapping, _, _) =>
+//          for {
+//            _ <- eknn.execute(createIndex(indexName))
+//            _ <- eknn.putMapping(indexName, vecField, storedIdField, mapping)
+//          } yield ()
+//      }
+//      _ <- Future.sequence(putMappingReqs)
+//
+//      indexReqs = inputs.map {
+//        case (indexName, _, vecs, ids) => eknn.index(indexName, vecField, vecs, storedIdField, ids)
+//      }
+//      _ <- Future.sequence(indexReqs)
+//      _ <- eknn.execute(refreshIndex(inputs.map(_._1)))
+//
+//      getReqs = inputs.map {
+//        case (indexName, _, _, ids) =>
+//          Future.sequence(ids.map(id => eknn.execute(get(indexName, id).fetchSourceInclude(vecField))))
+//      }
+//
+//      getResponses: Seq[Seq[Response[GetResponse]]] <- Future.sequence(getReqs)
+//
+//    } yield
+//      forAll(inputs.zip(getResponses)) {
+//        case ((_, _, vectors, _), getResponses) =>
+//          getResponses should have length vectors.length
+//          val parsedVectors = getResponses.map(_.result.sourceAsString).map(parse)
+//          forAll(parsedVectors)(_ shouldBe 'right)
+//          val encodedVectors = vectors.map(v => Json.fromJsonObject(JsonObject(vecField -> ElasticsearchCodec.encode(v))))
+//          forAll(encodedVectors)(v => parsedVectors should contain(Right(v)))
+//      }
+//  }
+//
+//  test("throw an error given vector with bad dimensions") {
+//    val index = s"test-intentional-failure-${UUID.randomUUID()}"
+//    val storedIdField = "id"
+//    val dims = 100
+//    val inputs = Seq(
+//      ("intentional-failure-sbv", Mapping.SparseBool(dims), Vec.SparseBool.random(dims + 1)),
+//      ("intentional-failure-dfv", Mapping.DenseFloat(dims), Vec.DenseFloat.random(dims + 1))
+//    )
+//    for {
+//      _ <- eknn.execute(createIndex(index))
+//      putMappingReqs = inputs.map {
+//        case (fieldName, mapping, _) => eknn.putMapping(index, fieldName, storedIdField, mapping)
+//      }
+//      _ <- Future.sequence(putMappingReqs)
+//
+//      indexReqs = inputs.map {
+//        case (fieldName, _, vec) =>
+//          recoverToExceptionIf[RuntimeException] {
+//            eknn.index(index, fieldName, Seq(vec), storedIdField, Seq(UUID.randomUUID().toString))
+//          }
+//      }
+//      exceptions <- Future.sequence(indexReqs)
+//
+//    } yield forAll(exceptions)(_.getMessage shouldBe "mapper_parsing_exception failed to parse")
+//  }
+
+  test("index shorthand dense float vectors") {
+
+    val (index, dims, vecField, idField) = ("issue-177", 10, "vec", "id")
+    val corpus = Vec.DenseFloat.randoms(dims, 100)
+    val mapping = Mapping.L2Lsh(dims, 20, 1, 2)
+    val ixReqs = corpus.zipWithIndex.map {
+      case (vec, i) =>
+        // val source = s""" { "$idField": "v$i", "$vecField": { "values": ${vec.values.asJson.noSpaces} } } """
+        val source = s""" { "$idField": "v$i", "$vecField": ${vec.values.asJson.noSpaces} } """
+        IndexRequest(index, source = Some(source))
+    }
     for {
-      createIndexRes <- eknn.execute(createIndex(index))
-      _ = createIndexRes.shouldBeSuccess
-
-      putMappingReqs = mappings.map {
-        case (vecField, mapping) => eknn.putMapping(index, vecField, storedIdField, mapping)
-      }
-      _ <- Future.sequence(putMappingReqs)
-
-      getMappingReqs = mappings.map {
-        case (fieldName, _) => eknn.execute(getMapping(Indexes(index), fieldName))
-      }
-      getMappingRes <- Future.sequence(getMappingReqs)
-    } yield
-      forAll(mappings.zip(getMappingRes)) {
-        case ((fieldName, mapping), res) =>
-          // Just check the JSON directly. Example structure:
-          // {
-          //  "test-226cf173-38d9-40e3-8c3d-3aabccd182ae": {
-          //    "mappings": {
-          //      "vec_spv": {
-          //        "full_name": "vec_spv",
-          //        "mapping": {
-          //          "vec_spv": {
-          //            "type": "elastiknn_sparse_bool_vector",
-          //            "elastiknn": {
-          //              "dims": 100
-          //            }
-          //          }
-          //        }
-          //      }
-          //    }
-          //  }
-          //}
-
-          res.body shouldBe defined
-          val json = parse(res.body.get)
-          json shouldBe 'right
-
-          val encoded = ElasticsearchCodec.encode(mapping)
-
-          val mappingJsonOpt: Option[JsonObject] = for {
-            x <- json.toOption
-            x <- x.findAllByKey(index).headOption
-            x <- x.findAllByKey("mappings").headOption
-            x <- x.findAllByKey(fieldName).headOption
-            x <- x.findAllByKey("mapping").headOption
-            x <- x.findAllByKey(fieldName).headOption
-            x <- x.asObject
-            y <- encoded.asObject
-            // The returned mapping might contain some more items, like similarity, so filter them out.
-          } yield x.filterKeys(y.keys.toSet.contains)
-
-          mappingJsonOpt shouldBe encoded.asObject
-      }
-
-  }
-
-  test("store and read vectors") {
-    val vecField = "vec"
-    val storedIdField = "id"
-    val (dims, n) = (100, 10)
-    def ids: Seq[String] = (0 until n).map(_ => UUID.randomUUID().toString)
-    val inputs: Seq[(String, Mapping, Vector[Vec], Seq[String])] = Seq(
-      // (index, mapping, random vectors, vector ids
-      (s"test-${UUID.randomUUID()}", Mapping.SparseBool(dims), Vec.SparseBool.randoms(dims, n), ids),
-      (s"test-${UUID.randomUUID()}", Mapping.DenseFloat(dims), Vec.DenseFloat.randoms(dims, n), ids),
-      (s"test-${UUID.randomUUID()}", Mapping.SparseIndexed(dims), Vec.SparseBool.randoms(dims, n), ids),
-      (s"test-${UUID.randomUUID()}", Mapping.JaccardLsh(dims, 65, 1), Vec.SparseBool.randoms(dims, n), ids)
-    )
-
-    for {
-      _ <- Future.successful(())
-
-      putMappingReqs = inputs.map {
-        case (indexName, mapping, _, _) =>
-          for {
-            _ <- eknn.execute(createIndex(indexName))
-            _ <- eknn.putMapping(indexName, vecField, storedIdField, mapping)
-          } yield ()
-      }
-      _ <- Future.sequence(putMappingReqs)
-
-      indexReqs = inputs.map {
-        case (indexName, _, vecs, ids) => eknn.index(indexName, vecField, vecs, storedIdField, ids)
-      }
-      _ <- Future.sequence(indexReqs)
-      _ <- eknn.execute(refreshIndex(inputs.map(_._1)))
-
-      getReqs = inputs.map {
-        case (indexName, _, _, ids) =>
-          Future.sequence(ids.map(id => eknn.execute(get(indexName, id).fetchSourceInclude(vecField))))
-      }
-
-      getResponses: Seq[Seq[Response[GetResponse]]] <- Future.sequence(getReqs)
-
-    } yield
-      forAll(inputs.zip(getResponses)) {
-        case ((_, _, vectors, _), getResponses) =>
-          getResponses should have length vectors.length
-          val parsedVectors = getResponses.map(_.result.sourceAsString).map(parse)
-          forAll(parsedVectors)(_ shouldBe 'right)
-          val encodedVectors = vectors.map(v => Json.fromJsonObject(JsonObject(vecField -> ElasticsearchCodec.encode(v))))
-          forAll(encodedVectors)(v => parsedVectors should contain(Right(v)))
-      }
-  }
-
-  test("throw an error given vector with bad dimensions") {
-    val index = s"test-intentional-failure-${UUID.randomUUID()}"
-    val storedIdField = "id"
-    val dims = 100
-    val inputs = Seq(
-      ("intentional-failure-sbv", Mapping.SparseBool(dims), Vec.SparseBool.random(dims + 1)),
-      ("intentional-failure-dfv", Mapping.DenseFloat(dims), Vec.DenseFloat.random(dims + 1))
-    )
-    for {
-      _ <- eknn.execute(createIndex(index))
-      putMappingReqs = inputs.map {
-        case (fieldName, mapping, _) => eknn.putMapping(index, fieldName, storedIdField, mapping)
-      }
-      _ <- Future.sequence(putMappingReqs)
-
-      indexReqs = inputs.map {
-        case (fieldName, _, vec) =>
-          recoverToExceptionIf[RuntimeException] {
-            eknn.index(index, fieldName, Seq(vec), storedIdField, Seq(UUID.randomUUID().toString))
-          }
-      }
-      exceptions <- Future.sequence(indexReqs)
-
-    } yield forAll(exceptions)(_.getMessage shouldBe "mapper_parsing_exception failed to parse")
+      _ <- deleteIfExists(index)
+      _ <- eknn.execute(createIndex(index).shards(1).replicas(0))
+      _ <- eknn.putMapping(index, vecField, idField, mapping)
+      _ <- eknn.execute(bulk(ixReqs))
+      _ <- eknn.execute(refreshIndex(index))
+      count <- eknn.execute(count(index).query(existsQuery(vecField)))
+    } yield count.result.count shouldBe corpus.length
   }
 
 }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/mapper/VectorMapperSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/mapper/VectorMapperSuite.scala
@@ -1,184 +1,175 @@
 package com.klibisz.elastiknn.mapper
 
-//import java.util.UUID
-//
-//import com.klibisz.elastiknn.api.{ElasticsearchCodec, Mapping, Vec}
-//import com.klibisz.elastiknn.testing.{Elastic4sMatchers, ElasticAsyncClient}
-//import com.sksamuel.elastic4s.ElasticDsl._
-//import com.sksamuel.elastic4s.requests.get.GetResponse
-//import com.sksamuel.elastic4s.requests.indexes.IndexRequest
-//import com.sksamuel.elastic4s.{Indexes, Response}
-//import io.circe.parser.parse
-//import io.circe.{Json, JsonObject}
-//import io.circe.syntax._
-//import org.scalatest._
-//
-//import scala.concurrent.Future
-//import scala.util.Random
+import java.util.UUID
 
-import com.klibisz.elastiknn.api.{Mapping, Vec}
+import com.klibisz.elastiknn.api.{ElasticsearchCodec, Mapping, NearestNeighborsQuery, Vec}
 import com.klibisz.elastiknn.testing.{Elastic4sMatchers, ElasticAsyncClient}
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
+import com.sksamuel.elastic4s.{Indexes, Response}
+import io.circe.parser.parse
+import io.circe.{Json, JsonObject}
 import io.circe.syntax._
 import org.scalatest._
 
+import scala.concurrent.Future
 import scala.util.Random
 
 class VectorMapperSuite extends AsyncFunSuite with Matchers with Inspectors with Elastic4sMatchers with ElasticAsyncClient {
 
   implicit val rng: Random = new Random(0)
 
-//  test("create index and put mapping") {
-//    val index = s"test-${UUID.randomUUID()}"
-//    val storedIdField = "id"
-//    val mappings: Seq[(String, Mapping)] = Seq(
-//      ("vec_spv", Mapping.SparseBool(100)),
-//      ("vec_dfv", Mapping.DenseFloat(100)),
-//      ("vec_spix", Mapping.SparseIndexed(100)),
-//      ("vec_jcdlsh", Mapping.JaccardLsh(100, 65, 1))
-//    )
-//    for {
-//      createIndexRes <- eknn.execute(createIndex(index))
-//      _ = createIndexRes.shouldBeSuccess
-//
-//      putMappingReqs = mappings.map {
-//        case (vecField, mapping) => eknn.putMapping(index, vecField, storedIdField, mapping)
-//      }
-//      _ <- Future.sequence(putMappingReqs)
-//
-//      getMappingReqs = mappings.map {
-//        case (fieldName, _) => eknn.execute(getMapping(Indexes(index), fieldName))
-//      }
-//      getMappingRes <- Future.sequence(getMappingReqs)
-//    } yield
-//      forAll(mappings.zip(getMappingRes)) {
-//        case ((fieldName, mapping), res) =>
-//          // Just check the JSON directly. Example structure:
-//          // {
-//          //  "test-226cf173-38d9-40e3-8c3d-3aabccd182ae": {
-//          //    "mappings": {
-//          //      "vec_spv": {
-//          //        "full_name": "vec_spv",
-//          //        "mapping": {
-//          //          "vec_spv": {
-//          //            "type": "elastiknn_sparse_bool_vector",
-//          //            "elastiknn": {
-//          //              "dims": 100
-//          //            }
-//          //          }
-//          //        }
-//          //      }
-//          //    }
-//          //  }
-//          //}
-//
-//          res.body shouldBe defined
-//          val json = parse(res.body.get)
-//          json shouldBe 'right
-//
-//          val encoded = ElasticsearchCodec.encode(mapping)
-//
-//          val mappingJsonOpt: Option[JsonObject] = for {
-//            x <- json.toOption
-//            x <- x.findAllByKey(index).headOption
-//            x <- x.findAllByKey("mappings").headOption
-//            x <- x.findAllByKey(fieldName).headOption
-//            x <- x.findAllByKey("mapping").headOption
-//            x <- x.findAllByKey(fieldName).headOption
-//            x <- x.asObject
-//            y <- encoded.asObject
-//            // The returned mapping might contain some more items, like similarity, so filter them out.
-//          } yield x.filterKeys(y.keys.toSet.contains)
-//
-//          mappingJsonOpt shouldBe encoded.asObject
-//      }
-//
-//  }
-//
-//  test("store and read vectors") {
-//    val vecField = "vec"
-//    val storedIdField = "id"
-//    val (dims, n) = (100, 10)
-//    def ids: Seq[String] = (0 until n).map(_ => UUID.randomUUID().toString)
-//    val inputs: Seq[(String, Mapping, Vector[Vec], Seq[String])] = Seq(
-//      // (index, mapping, random vectors, vector ids
-//      (s"test-${UUID.randomUUID()}", Mapping.SparseBool(dims), Vec.SparseBool.randoms(dims, n), ids),
-//      (s"test-${UUID.randomUUID()}", Mapping.DenseFloat(dims), Vec.DenseFloat.randoms(dims, n), ids),
-//      (s"test-${UUID.randomUUID()}", Mapping.SparseIndexed(dims), Vec.SparseBool.randoms(dims, n), ids),
-//      (s"test-${UUID.randomUUID()}", Mapping.JaccardLsh(dims, 65, 1), Vec.SparseBool.randoms(dims, n), ids)
-//    )
-//
-//    for {
-//      _ <- Future.successful(())
-//
-//      putMappingReqs = inputs.map {
-//        case (indexName, mapping, _, _) =>
-//          for {
-//            _ <- eknn.execute(createIndex(indexName))
-//            _ <- eknn.putMapping(indexName, vecField, storedIdField, mapping)
-//          } yield ()
-//      }
-//      _ <- Future.sequence(putMappingReqs)
-//
-//      indexReqs = inputs.map {
-//        case (indexName, _, vecs, ids) => eknn.index(indexName, vecField, vecs, storedIdField, ids)
-//      }
-//      _ <- Future.sequence(indexReqs)
-//      _ <- eknn.execute(refreshIndex(inputs.map(_._1)))
-//
-//      getReqs = inputs.map {
-//        case (indexName, _, _, ids) =>
-//          Future.sequence(ids.map(id => eknn.execute(get(indexName, id).fetchSourceInclude(vecField))))
-//      }
-//
-//      getResponses: Seq[Seq[Response[GetResponse]]] <- Future.sequence(getReqs)
-//
-//    } yield
-//      forAll(inputs.zip(getResponses)) {
-//        case ((_, _, vectors, _), getResponses) =>
-//          getResponses should have length vectors.length
-//          val parsedVectors = getResponses.map(_.result.sourceAsString).map(parse)
-//          forAll(parsedVectors)(_ shouldBe 'right)
-//          val encodedVectors = vectors.map(v => Json.fromJsonObject(JsonObject(vecField -> ElasticsearchCodec.encode(v))))
-//          forAll(encodedVectors)(v => parsedVectors should contain(Right(v)))
-//      }
-//  }
-//
-//  test("throw an error given vector with bad dimensions") {
-//    val index = s"test-intentional-failure-${UUID.randomUUID()}"
-//    val storedIdField = "id"
-//    val dims = 100
-//    val inputs = Seq(
-//      ("intentional-failure-sbv", Mapping.SparseBool(dims), Vec.SparseBool.random(dims + 1)),
-//      ("intentional-failure-dfv", Mapping.DenseFloat(dims), Vec.DenseFloat.random(dims + 1))
-//    )
-//    for {
-//      _ <- eknn.execute(createIndex(index))
-//      putMappingReqs = inputs.map {
-//        case (fieldName, mapping, _) => eknn.putMapping(index, fieldName, storedIdField, mapping)
-//      }
-//      _ <- Future.sequence(putMappingReqs)
-//
-//      indexReqs = inputs.map {
-//        case (fieldName, _, vec) =>
-//          recoverToExceptionIf[RuntimeException] {
-//            eknn.index(index, fieldName, Seq(vec), storedIdField, Seq(UUID.randomUUID().toString))
-//          }
-//      }
-//      exceptions <- Future.sequence(indexReqs)
-//
-//    } yield forAll(exceptions)(_.getMessage shouldBe "mapper_parsing_exception failed to parse")
-//  }
+  test("create index and put mapping") {
+    val index = s"test-${UUID.randomUUID()}"
+    val storedIdField = "id"
+    val mappings: Seq[(String, Mapping)] = Seq(
+      ("vec_spv", Mapping.SparseBool(100)),
+      ("vec_dfv", Mapping.DenseFloat(100)),
+      ("vec_spix", Mapping.SparseIndexed(100)),
+      ("vec_jcdlsh", Mapping.JaccardLsh(100, 65, 1))
+    )
+    for {
+      createIndexRes <- eknn.execute(createIndex(index))
+      _ = createIndexRes.shouldBeSuccess
 
+      putMappingReqs = mappings.map {
+        case (vecField, mapping) => eknn.putMapping(index, vecField, storedIdField, mapping)
+      }
+      _ <- Future.sequence(putMappingReqs)
+
+      getMappingReqs = mappings.map {
+        case (fieldName, _) => eknn.execute(getMapping(Indexes(index), fieldName))
+      }
+      getMappingRes <- Future.sequence(getMappingReqs)
+    } yield
+      forAll(mappings.zip(getMappingRes)) {
+        case ((fieldName, mapping), res) =>
+          // Just check the JSON directly. Example structure:
+          // {
+          //  "test-226cf173-38d9-40e3-8c3d-3aabccd182ae": {
+          //    "mappings": {
+          //      "vec_spv": {
+          //        "full_name": "vec_spv",
+          //        "mapping": {
+          //          "vec_spv": {
+          //            "type": "elastiknn_sparse_bool_vector",
+          //            "elastiknn": {
+          //              "dims": 100
+          //            }
+          //          }
+          //        }
+          //      }
+          //    }
+          //  }
+          //}
+
+          res.body shouldBe defined
+          val json = parse(res.body.get)
+          json shouldBe 'right
+
+          val encoded = ElasticsearchCodec.encode(mapping)
+
+          val mappingJsonOpt: Option[JsonObject] = for {
+            x <- json.toOption
+            x <- x.findAllByKey(index).headOption
+            x <- x.findAllByKey("mappings").headOption
+            x <- x.findAllByKey(fieldName).headOption
+            x <- x.findAllByKey("mapping").headOption
+            x <- x.findAllByKey(fieldName).headOption
+            x <- x.asObject
+            y <- encoded.asObject
+            // The returned mapping might contain some more items, like similarity, so filter them out.
+          } yield x.filterKeys(y.keys.toSet.contains)
+
+          mappingJsonOpt shouldBe encoded.asObject
+      }
+
+  }
+
+  test("store and read vectors") {
+    val vecField = "vec"
+    val storedIdField = "id"
+    val (dims, n) = (100, 10)
+    def ids: Seq[String] = (0 until n).map(_ => UUID.randomUUID().toString)
+    val inputs: Seq[(String, Mapping, Vector[Vec], Seq[String])] = Seq(
+      // (index, mapping, random vectors, vector ids
+      (s"test-${UUID.randomUUID()}", Mapping.SparseBool(dims), Vec.SparseBool.randoms(dims, n), ids),
+      (s"test-${UUID.randomUUID()}", Mapping.DenseFloat(dims), Vec.DenseFloat.randoms(dims, n), ids),
+      (s"test-${UUID.randomUUID()}", Mapping.SparseIndexed(dims), Vec.SparseBool.randoms(dims, n), ids),
+      (s"test-${UUID.randomUUID()}", Mapping.JaccardLsh(dims, 65, 1), Vec.SparseBool.randoms(dims, n), ids)
+    )
+
+    for {
+      _ <- Future.successful(())
+
+      putMappingReqs = inputs.map {
+        case (indexName, mapping, _, _) =>
+          for {
+            _ <- eknn.execute(createIndex(indexName))
+            _ <- eknn.putMapping(indexName, vecField, storedIdField, mapping)
+          } yield ()
+      }
+      _ <- Future.sequence(putMappingReqs)
+
+      indexReqs = inputs.map {
+        case (indexName, _, vecs, ids) => eknn.index(indexName, vecField, vecs, storedIdField, ids)
+      }
+      _ <- Future.sequence(indexReqs)
+      _ <- eknn.execute(refreshIndex(inputs.map(_._1)))
+
+      getReqs = inputs.map {
+        case (indexName, _, _, ids) =>
+          Future.sequence(ids.map(id => eknn.execute(get(indexName, id).fetchSourceInclude(vecField))))
+      }
+
+      getResponses: Seq[Seq[Response[GetResponse]]] <- Future.sequence(getReqs)
+
+    } yield
+      forAll(inputs.zip(getResponses)) {
+        case ((_, _, vectors, _), getResponses) =>
+          getResponses should have length vectors.length
+          val parsedVectors = getResponses.map(_.result.sourceAsString).map(parse)
+          forAll(parsedVectors)(_ shouldBe 'right)
+          val encodedVectors = vectors.map(v => Json.fromJsonObject(JsonObject(vecField -> ElasticsearchCodec.encode(v))))
+          forAll(encodedVectors)(v => parsedVectors should contain(Right(v)))
+      }
+  }
+
+  test("throw an error given vector with bad dimensions") {
+    val index = s"test-intentional-failure-${UUID.randomUUID()}"
+    val storedIdField = "id"
+    val dims = 100
+    val inputs = Seq(
+      ("intentional-failure-sbv", Mapping.SparseBool(dims), Vec.SparseBool.random(dims + 1)),
+      ("intentional-failure-dfv", Mapping.DenseFloat(dims), Vec.DenseFloat.random(dims + 1))
+    )
+    for {
+      _ <- eknn.execute(createIndex(index))
+      putMappingReqs = inputs.map {
+        case (fieldName, mapping, _) => eknn.putMapping(index, fieldName, storedIdField, mapping)
+      }
+      _ <- Future.sequence(putMappingReqs)
+
+      indexReqs = inputs.map {
+        case (fieldName, _, vec) =>
+          recoverToExceptionIf[RuntimeException] {
+            eknn.index(index, fieldName, Seq(vec), storedIdField, Seq(UUID.randomUUID().toString))
+          }
+      }
+      exceptions <- Future.sequence(indexReqs)
+
+    } yield forAll(exceptions)(_.getMessage shouldBe "mapper_parsing_exception failed to parse")
+  }
+
+  // https://github.com/alexklibisz/elastiknn/issues/177
   test("index shorthand dense float vectors") {
 
-    val (index, dims, vecField, idField) = ("issue-177", 10, "vec", "id")
-    val corpus = Vec.DenseFloat.randoms(dims, 100)
-    val mapping = Mapping.L2Lsh(dims, 20, 1, 2)
+    val (index, dims, vecField, idField) = ("issue-177", 42, "vec", "id")
+    val corpus = Vec.DenseFloat.randoms(dims, 1000)
+    val mapping = Mapping.L2Lsh(dims, 33, 1, 1)
     val ixReqs = corpus.zipWithIndex.map {
       case (vec, i) =>
-        // val source = s""" { "$idField": "v$i", "$vecField": { "values": ${vec.values.asJson.noSpaces} } } """
         val source = s""" { "$idField": "v$i", "$vecField": ${vec.values.asJson.noSpaces} } """
         IndexRequest(index, source = Some(source))
     }
@@ -189,7 +180,12 @@ class VectorMapperSuite extends AsyncFunSuite with Matchers with Inspectors with
       _ <- eknn.execute(bulk(ixReqs))
       _ <- eknn.execute(refreshIndex(index))
       count <- eknn.execute(count(index).query(existsQuery(vecField)))
-    } yield count.result.count shouldBe corpus.length
+      nbrs <- eknn.nearestNeighbors(index, NearestNeighborsQuery.L2Lsh(vecField, 10, 1, corpus.head), 10, idField)
+    } yield {
+      count.result.count shouldBe corpus.length
+      nbrs.result.hits.hits.length shouldBe 10
+      nbrs.result.hits.hits.head.id shouldBe "v0"
+    }
   }
 
 }


### PR DESCRIPTION
Based on #177 

Introduces a shorthand alternative format for dense and sparse vectors that makes it easier to work with ES-connectors that don't allow nested docs.

Dense vectors can be represented as a simple array:

`{ "vec": [0.1, 0.2, 0.3, ...] }` is equivalent to `{ "vec": { "values": [0.1, 0.2, 0.3] }}`.

`{"vec": [[1, 3, 5, ...], 100] }` is equivalent to `{ "vec": { "true_indices": [1,3,5,...], "total_indices": 100 }}`


The main trick in getting this to work was figuring out I had to make the `FieldMapper` extend the `ArrayValueMapperParser` in order for Elasticsearch to let me parse a Json Array. 