### PR TITLE
Vector caching (optimization intended mainly for 7.9.2 upgrade)

### DIFF
--- a/.esopts
+++ b/.esopts
@@ -2,3 +2,6 @@
 -Dtests.es.indices.query.bool.max_clause_count=4096
 -Dtests.es.node.processors=1
 -Dtests.es.thread_pool.search.size=1
+-Dtests.es.elastiknn.cache.enabled=true
+-Dtests.es.elastiknn.cache.capacity_mb=512
+-Dtests.es.elastiknn.cache.ttl_seconds=60

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+- Adds a global guava cache for dense vectors and another for sparse vectors.
+  The main motivation for this is that versions above 7.6.2 use a version of Lucene that introduced higher compression to binary doc values fields. 
+  So it takes significantly longer to consume the vectors from Lucene to do exact similarity scoring.
+  Caching is configurable using the parameters below, shown with their default values:
+  ```
+  elastiknn.cache.enabled=false    # whether to use caching
+  elastiknn.cache.capacity_mb=512  # capacity limit of each cache in megabytes
+  elastiknn.cache.ttl_seconds=600  # TTL (expire-after-write) for any entry in each cache
+  ```
+---
 - Introduces a shorthand alternative format for dense and sparse vectors that makes it easier to work with ES-connectors that don't allow nested docs.
   - Dense vectors can be represented as a simple array: `{ "vec": [0.1, 0.2, 0.3, ...] }` is equivalent to `{ "vec": { "values": [0.1, 0.2, 0.3] }}`.
   - Sparse vectors can be represented as an array where the first element is the array of true indices, and the second is the number of total indices: `{"vec": [[1, 3, 5, ...], 100] }` is equivalent to `{ "vec": { "true_indices": [1,3,5,...], "total_indices": 100 }}`

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/ElastiknnPlugin.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/ElastiknnPlugin.scala
@@ -13,26 +13,27 @@ import org.elasticsearch.plugins._
 
 class ElastiknnPlugin(settings: Settings) extends Plugin with IngestPlugin with SearchPlugin with ActionPlugin with MapperPlugin {
 
-  private val processors: Int = Runtime.getRuntime.availableProcessors()
-
+  // Cache settings. The caches are instantiated in `getQueries` based on these settings.
   private val cacheEnabled = Setting.boolSetting("elastiknn.cache.enabled", false, NodeScope, Final)
-  private val cacheCapacityBytes = Setting.longSetting("elastiknn.cache.capacity_bytes", 5e8.toLong, 0, NodeScope, Final)
+  private val cacheCapacityMb = Setting.longSetting("elastiknn.cache.capacity_mb", 512, 0, NodeScope, Final)
   private val cacheTTLSeconds = Setting.longSetting("elastiknn.cache.ttl_seconds", 600, 0, NodeScope, Final)
 
-  private val denseCache: VectorCache[StoredVec.DenseFloat] =
-    if (cacheEnabled.get(settings)) VectorCache(processors, cacheCapacityBytes.get(settings), cacheTTLSeconds.get(settings))
-    else VectorCache.empty
-  private val sparseCache: VectorCache[StoredVec.SparseBool] =
-    if (cacheEnabled.get(settings)) VectorCache(processors, cacheCapacityBytes.get(settings), cacheTTLSeconds.get(settings))
-    else VectorCache.empty
+  override def getSettings: util.List[Setting[_]] = util.List.of(cacheEnabled, cacheCapacityMb, cacheTTLSeconds)
 
-  override def getSettings: util.List[Setting[_]] = util.List.of(cacheEnabled, cacheCapacityBytes, cacheTTLSeconds)
-
-  override def getQueries: util.List[SearchPlugin.QuerySpec[_]] = util.Arrays.asList(
-    new QuerySpec(KnnQueryBuilder.NAME,
-                  new KnnQueryBuilder.Reader(denseCache, sparseCache),
-                  new KnnQueryBuilder.Parser(denseCache, sparseCache))
-  )
+  override def getQueries: util.List[SearchPlugin.QuerySpec[_]] = {
+    val processors: Int = Runtime.getRuntime.availableProcessors()
+    val denseCache: VectorCache[StoredVec.DenseFloat] =
+      if (cacheEnabled.get(settings)) VectorCache(processors, cacheCapacityMb.get(settings), cacheTTLSeconds.get(settings))
+      else VectorCache.empty
+    val sparseCache: VectorCache[StoredVec.SparseBool] =
+      if (cacheEnabled.get(settings)) VectorCache(processors, cacheCapacityMb.get(settings), cacheTTLSeconds.get(settings))
+      else VectorCache.empty
+    util.Arrays.asList(
+      new QuerySpec(KnnQueryBuilder.NAME,
+                    new KnnQueryBuilder.Reader(denseCache, sparseCache),
+                    new KnnQueryBuilder.Parser(denseCache, sparseCache))
+    )
+  }
 
   override def getMappers: util.Map[String, Mapper.TypeParser] =
     new util.HashMap[String, Mapper.TypeParser] {

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/ElastiknnPlugin.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/ElastiknnPlugin.scala
@@ -4,23 +4,40 @@ import java.util
 
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.query._
-import org.elasticsearch.common.settings.Settings
+import com.klibisz.elastiknn.storage.{StoredVec, VectorCache}
+import org.elasticsearch.common.settings.{Setting, Settings}
 import org.elasticsearch.index.mapper.Mapper
+import org.elasticsearch.common.settings.Setting.Property.{Final, NodeScope}
 import org.elasticsearch.plugins.SearchPlugin.QuerySpec
 import org.elasticsearch.plugins._
 
 class ElastiknnPlugin(settings: Settings) extends Plugin with IngestPlugin with SearchPlugin with ActionPlugin with MapperPlugin {
 
+  private val processors: Int = Runtime.getRuntime.availableProcessors()
+
+  private val cacheEnabled = Setting.boolSetting("elastiknn.cache.enabled", false, NodeScope, Final)
+  private val cacheCapacityBytes = Setting.longSetting("elastiknn.cache.capacity_bytes", 5e8.toLong, 0, NodeScope, Final)
+  private val cacheTTLSeconds = Setting.longSetting("elastiknn.cache.ttl_seconds", 600, 0, NodeScope, Final)
+
+  private val denseCache: VectorCache[StoredVec.DenseFloat] =
+    if (cacheEnabled.get(settings)) VectorCache(processors, cacheCapacityBytes.get(settings), cacheTTLSeconds.get(settings))
+    else VectorCache.empty
+  private val sparseCache: VectorCache[StoredVec.SparseBool] =
+    if (cacheEnabled.get(settings)) VectorCache(processors, cacheCapacityBytes.get(settings), cacheTTLSeconds.get(settings))
+    else VectorCache.empty
+
+  override def getSettings: util.List[Setting[_]] = util.List.of(cacheEnabled, cacheCapacityBytes, cacheTTLSeconds)
+
   override def getQueries: util.List[SearchPlugin.QuerySpec[_]] = util.Arrays.asList(
-    new QuerySpec(KnnQueryBuilder.NAME, KnnQueryBuilder.Reader, KnnQueryBuilder.Parser)
+    new QuerySpec(KnnQueryBuilder.NAME,
+                  new KnnQueryBuilder.Reader(denseCache, sparseCache),
+                  new KnnQueryBuilder.Parser(denseCache, sparseCache))
   )
 
-  override def getMappers: util.Map[String, Mapper.TypeParser] = {
-    import VectorMapper._
+  override def getMappers: util.Map[String, Mapper.TypeParser] =
     new util.HashMap[String, Mapper.TypeParser] {
-      put(sparseBoolVector.CONTENT_TYPE, new sparseBoolVector.TypeParser)
-      put(denseFloatVector.CONTENT_TYPE, new denseFloatVector.TypeParser)
+      put(VectorMapper.sparseBoolVector.CONTENT_TYPE, new VectorMapper.sparseBoolVector.TypeParser)
+      put(VectorMapper.denseFloatVector.CONTENT_TYPE, new VectorMapper.denseFloatVector.TypeParser)
     }
-  }
 
 }

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/HashingQuery.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/HashingQuery.scala
@@ -2,7 +2,7 @@ package com.klibisz.elastiknn.query
 
 import com.klibisz.elastiknn.api.{Mapping, Vec}
 import com.klibisz.elastiknn.models.{ExactSimilarityFunction, HashAndFreq, HashingFunction}
-import com.klibisz.elastiknn.storage.StoredVec
+import com.klibisz.elastiknn.storage.{StoredVec, VectorCache}
 import org.apache.lucene.document.Field
 import org.apache.lucene.index.{IndexReader, IndexableField, LeafReaderContext}
 import org.apache.lucene.search.{MatchHashesAndScoreQuery, Query}
@@ -16,10 +16,11 @@ object HashingQuery {
                                       limit: Float,
                                       hashes: Array[HashAndFreq],
                                       exactFunction: ExactSimilarityFunction[V, S],
-                                      indexReader: IndexReader)(implicit codec: StoredVec.Codec[V, S]): Query = {
+                                      indexReader: IndexReader,
+                                      cache: VectorCache[S])(implicit codec: StoredVec.Codec[V, S]): Query = {
     val scoreFunction: java.util.function.Function[LeafReaderContext, MatchHashesAndScoreQuery.ScoreFunction] =
       (lrc: LeafReaderContext) => {
-        val reader = new ExactQuery.StoredVecReader[S](lrc, field)
+        val reader = new ExactQuery.StoredVecReader[S](lrc, field, cache)
         (docId: Int, _: Int) =>
           val storedVec = reader(docId)
           exactFunction(query, storedVec)

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnQueryBuilder.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnQueryBuilder.scala
@@ -8,6 +8,8 @@ import com.klibisz.elastiknn.api.ElasticsearchCodec._
 import com.klibisz.elastiknn.api._
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.models.{SparseIndexedSimilarityFunction, Cache => ModelCache}
+import com.klibisz.elastiknn.query.KnnQueryBuilder.incompatible
+import com.klibisz.elastiknn.storage.VectorCache.{DenseCache, SparseCache}
 import com.klibisz.elastiknn.utils.CirceUtils.javaMapEncoder
 import com.klibisz.elastiknn.{ELASTIKNN_NAME, api}
 import io.circe.Json
@@ -30,7 +32,7 @@ object KnnQueryBuilder {
   private def encodeB64[T: ElasticsearchCodec](t: T): String = b64.encode(encode(t).noSpaces.getBytes)
   private def decodeB64[T: ElasticsearchCodec](s: String): T = parse(new String(b64.decode(s))).flatMap(decodeJson[T]).toTry.get
 
-  object Parser extends QueryParser[KnnQueryBuilder] {
+  class Parser(denseCache: DenseCache, sparseCache: SparseCache) extends QueryParser[KnnQueryBuilder] {
     override def fromXContent(parser: XContentParser): KnnQueryBuilder = {
       val map = parser.map()
       val json: Json = javaMapEncoder(map)
@@ -40,75 +42,20 @@ object KnnQueryBuilder {
         case v: Vec.SparseBool if !v.isSorted => v.sorted()
         case _                                => query.vec
       }
-      new KnnQueryBuilder(query.withVec(sortedVec))
+      new KnnQueryBuilder(query.withVec(sortedVec), denseCache, sparseCache)
     }
   }
 
-  object Reader extends Writeable.Reader[KnnQueryBuilder] {
+  class Reader(denseCache: DenseCache, sparseCache: SparseCache) extends Writeable.Reader[KnnQueryBuilder] {
     override def read(in: StreamInput): KnnQueryBuilder = {
       in.readFloat() // boost
       in.readOptionalString() // query name
       val query = decodeB64[NearestNeighborsQuery](in.readString())
-      new KnnQueryBuilder(query)
+      new KnnQueryBuilder(query, denseCache, sparseCache)
     }
   }
 
-  def apply(query: NearestNeighborsQuery, mapping: Mapping, indexReader: IndexReader): Query = {
-    import NearestNeighborsQuery._
-    import com.klibisz.elastiknn.models.{ExactSimilarityFunction => ESF}
-
-    (query, mapping) match {
-
-      case (Exact(f, Similarity.Jaccard, v: Vec.SparseBool),
-            _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh) =>
-        ExactQuery(f, v, ESF.Jaccard)
-
-      case (Exact(f, Similarity.Hamming, v: Vec.SparseBool),
-            _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh) =>
-        ExactQuery(f, v, ESF.Hamming)
-
-      case (Exact(f, Similarity.L1, v: Vec.DenseFloat),
-            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh) =>
-        ExactQuery(f, v, ESF.L1)
-
-      case (Exact(f, Similarity.L2, v: Vec.DenseFloat),
-            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh) =>
-        ExactQuery(f, v, ESF.L2)
-
-      case (Exact(f, Similarity.Angular, v: Vec.DenseFloat),
-            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh) =>
-        ExactQuery(f, v, ESF.Angular)
-
-      case (SparseIndexed(f, Similarity.Jaccard, sbv: Vec.SparseBool), _: Mapping.SparseIndexed) =>
-        SparseIndexedQuery(f, sbv, SparseIndexedSimilarityFunction.Jaccard, indexReader)
-
-      case (SparseIndexed(f, Similarity.Hamming, sbv: Vec.SparseBool), _: Mapping.SparseIndexed) =>
-        SparseIndexedQuery(f, sbv, SparseIndexedSimilarityFunction.Hamming, indexReader)
-
-      case (JaccardLsh(f, candidates, v: Vec.SparseBool, l: Float), m: Mapping.JaccardLsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.trueIndices, v.totalIndices), ESF.Jaccard, indexReader)
-
-      case (HammingLsh(f, candidates, v: Vec.SparseBool, l: Float), m: Mapping.HammingLsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.trueIndices, v.totalIndices), ESF.Hamming, indexReader)
-
-      case (AngularLsh(f, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.AngularLsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.Angular, indexReader)
-
-      case (L2Lsh(f, candidates, probes, v: Vec.DenseFloat, l: Float), m: Mapping.L2Lsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values, probes), ESF.L2, indexReader)
-
-      case (PermutationLsh(f, Similarity.Angular, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.PermutationLsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.Angular, indexReader)
-
-      case (PermutationLsh(f, Similarity.L2, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.PermutationLsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.L2, indexReader)
-
-      case (PermutationLsh(f, Similarity.L1, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.PermutationLsh) =>
-        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.L1, indexReader)
-
-      case _ => throw incompatible(mapping, query)
-    }
-  }
+  def apply(query: NearestNeighborsQuery, mapping: Mapping, indexReader: IndexReader): Query = ???
 
   private def incompatible(m: Mapping, q: NearestNeighborsQuery): Exception = {
     val msg = s"Query [${ElasticsearchCodec.encode(q).noSpaces}] is not compatible with mapping [${ElasticsearchCodec.encode(m).noSpaces}]"
@@ -117,11 +64,10 @@ object KnnQueryBuilder {
 
 }
 
-final case class KnnQueryBuilder(query: NearestNeighborsQuery) extends AbstractQueryBuilder[KnnQueryBuilder] {
+final case class KnnQueryBuilder(query: NearestNeighborsQuery, denseCache: DenseCache, sparseCache: SparseCache)
+    extends AbstractQueryBuilder[KnnQueryBuilder] {
 
-  override def doWriteTo(out: StreamOutput): Unit = {
-    out.writeString(KnnQueryBuilder.encodeB64(query))
-  }
+  override def doWriteTo(out: StreamOutput): Unit = out.writeString(KnnQueryBuilder.encodeB64(query))
 
   override def doXContent(builder: XContentBuilder, params: ToXContent.Params): Unit = ()
 
@@ -130,7 +76,64 @@ final case class KnnQueryBuilder(query: NearestNeighborsQuery) extends AbstractQ
     case _                => this
   }
 
-  override def doToQuery(context: QueryShardContext): Query = KnnQueryBuilder(query, getMapping(context), context.getIndexReader)
+  override def doToQuery(context: QueryShardContext): Query = {
+    import NearestNeighborsQuery._
+    import com.klibisz.elastiknn.models.{ExactSimilarityFunction => ESF}
+    val mapping = getMapping(context)
+    val indexReader = context.getIndexReader
+
+    (query, mapping) match {
+
+      case (Exact(f, Similarity.Jaccard, v: Vec.SparseBool),
+            _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh) =>
+        ExactQuery(f, v, ESF.Jaccard, sparseCache)
+
+      case (Exact(f, Similarity.Hamming, v: Vec.SparseBool),
+            _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh) =>
+        ExactQuery(f, v, ESF.Hamming, sparseCache)
+
+      case (Exact(f, Similarity.L1, v: Vec.DenseFloat),
+            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh) =>
+        ExactQuery(f, v, ESF.L1, denseCache)
+
+      case (Exact(f, Similarity.L2, v: Vec.DenseFloat),
+            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh) =>
+        ExactQuery(f, v, ESF.L2, denseCache)
+
+      case (Exact(f, Similarity.Angular, v: Vec.DenseFloat),
+            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh) =>
+        ExactQuery(f, v, ESF.Angular, denseCache)
+
+      case (SparseIndexed(f, Similarity.Jaccard, sbv: Vec.SparseBool), _: Mapping.SparseIndexed) =>
+        SparseIndexedQuery(f, sbv, SparseIndexedSimilarityFunction.Jaccard, indexReader)
+
+      case (SparseIndexed(f, Similarity.Hamming, sbv: Vec.SparseBool), _: Mapping.SparseIndexed) =>
+        SparseIndexedQuery(f, sbv, SparseIndexedSimilarityFunction.Hamming, indexReader)
+
+      case (JaccardLsh(f, candidates, v: Vec.SparseBool, l: Float), m: Mapping.JaccardLsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.trueIndices, v.totalIndices), ESF.Jaccard, indexReader, sparseCache)
+
+      case (HammingLsh(f, candidates, v: Vec.SparseBool, l: Float), m: Mapping.HammingLsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.trueIndices, v.totalIndices), ESF.Hamming, indexReader, sparseCache)
+
+      case (AngularLsh(f, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.AngularLsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.Angular, indexReader, denseCache)
+
+      case (L2Lsh(f, candidates, probes, v: Vec.DenseFloat, l: Float), m: Mapping.L2Lsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values, probes), ESF.L2, indexReader, denseCache)
+
+      case (PermutationLsh(f, Similarity.Angular, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.PermutationLsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.Angular, indexReader, denseCache)
+
+      case (PermutationLsh(f, Similarity.L2, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.PermutationLsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.L2, indexReader, denseCache)
+
+      case (PermutationLsh(f, Similarity.L1, candidates, v: Vec.DenseFloat, l: Float), m: Mapping.PermutationLsh) =>
+        HashingQuery(f, v, candidates, l, ModelCache(m).hash(v.values), ESF.L1, indexReader, denseCache)
+
+      case _ => throw incompatible(mapping, query)
+    }
+  }
 
   private def getMapping(context: QueryShardContext): Mapping = {
     import VectorMapper._

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/storage/StoredVec.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/storage/StoredVec.scala
@@ -26,13 +26,16 @@ import scala.language.implicitConversions
   *  Anything using Unsafe comes with the tradeoff that it requires extra JVM security permissions.
   *  If this becomes a problem we should likely switch to ObjectOutput/InputStreams.
   */
-sealed trait StoredVec
+sealed trait StoredVec {
+  def sizeBytes: Int
+}
 
 object StoredVec {
 
   sealed trait SparseBool extends StoredVec {
     val trueIndices: Array[Int]
     override def hashCode: Int = util.Arrays.hashCode(trueIndices)
+    override def sizeBytes: Int = trueIndices.length * 4 + 4
   }
 
   object SparseBool {
@@ -44,6 +47,7 @@ object StoredVec {
   sealed trait DenseFloat extends StoredVec {
     val values: Array[Float]
     override def hashCode: Int = util.Arrays.hashCode(values)
+    override def sizeBytes: Int = values.length * 4 + 4
   }
 
   object DenseFloat {

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/storage/VectorCache.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/storage/VectorCache.scala
@@ -1,0 +1,30 @@
+package com.klibisz.elastiknn.storage
+
+import java.util.concurrent.TimeUnit
+
+import com.google.common.cache.{Cache, CacheBuilder}
+
+trait VectorCache[S <: StoredVec] {
+  def apply(key: VectorCache.Key, set: () => S): S
+}
+
+object VectorCache {
+
+  type DenseCache = VectorCache[StoredVec.DenseFloat]
+  type SparseCache = VectorCache[StoredVec.SparseBool]
+
+  case class Key(docId: Int, field: String, contextHashCode: Long)
+
+  def apply[S <: StoredVec](concurrency: Int, capacityBytes: Long, ttlSeconds: Long): VectorCache[S] = new VectorCache[S] {
+    private val cache: Cache[Key, S] = CacheBuilder.newBuilder
+      .concurrencyLevel(concurrency)
+      .maximumWeight(capacityBytes)
+      .weigher((_: Key, value: S) => value.sizeBytes)
+      .expireAfterWrite(ttlSeconds, TimeUnit.SECONDS)
+      .build()
+    override def apply(key: Key, set: () => S): S = cache.get(key, () => set())
+  }
+
+  def empty[S <: StoredVec]: VectorCache[S] = (_, set: () => S) => set()
+
+}

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/storage/VectorCache.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/storage/VectorCache.scala
@@ -15,10 +15,10 @@ object VectorCache {
 
   case class Key(docId: Int, field: String, contextHashCode: Long)
 
-  def apply[S <: StoredVec](concurrency: Int, capacityBytes: Long, ttlSeconds: Long): VectorCache[S] = new VectorCache[S] {
+  def apply[S <: StoredVec](concurrency: Int, capacityMb: Long, ttlSeconds: Long): VectorCache[S] = new VectorCache[S] {
     private val cache: Cache[Key, S] = CacheBuilder.newBuilder
       .concurrencyLevel(concurrency)
-      .maximumWeight(capacityBytes)
+      .maximumWeight(capacityMb * 1000000) // mb to bytes
       .weigher((_: Key, value: S) => value.sizeBytes)
       .expireAfterWrite(ttlSeconds, TimeUnit.SECONDS)
       .build()

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/PermutationLshModelSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/PermutationLshModelSuite.scala
@@ -4,6 +4,7 @@ import com.klibisz.elastiknn.api.{Mapping, Vec}
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.query.HashingQuery
 import com.klibisz.elastiknn.storage.UnsafeSerialization._
+import com.klibisz.elastiknn.storage.VectorCache
 import com.klibisz.elastiknn.testing.LuceneSupport
 import org.apache.lucene.document.{Document, Field}
 import org.apache.lucene.index.LeafReaderContext
@@ -109,7 +110,7 @@ class PermutationLshModelSuite extends FunSuite with Matchers with LuceneSupport
       } {
         case (r, s) =>
           queryVecs.map { v =>
-            val q = HashingQuery("vec", v, 200, 1f, lsh.hash(v.values), ExactSimilarityFunction.Angular, r)
+            val q = HashingQuery("vec", v, 200, 1f, lsh.hash(v.values), ExactSimilarityFunction.Angular, r, VectorCache.empty)
             s.search(q, 100).scoreDocs.map(sd => (sd.doc, sd.score)).toVector
           }
       }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MatchHashesAndScoreQueryPerformanceSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MatchHashesAndScoreQueryPerformanceSuite.scala
@@ -3,6 +3,7 @@ package com.klibisz.elastiknn.query
 import com.klibisz.elastiknn.api.{Mapping, Vec}
 import com.klibisz.elastiknn.mapper.VectorMapper
 import com.klibisz.elastiknn.models.{ExactSimilarityFunction, L2LshModel}
+import com.klibisz.elastiknn.storage.VectorCache
 import com.klibisz.elastiknn.testing.LuceneSupport
 import org.apache.lucene.codecs.lucene84.Lucene84Codec
 import org.apache.lucene.document.Document
@@ -46,7 +47,7 @@ class MatchHashesAndScoreQueryPerformanceSuite extends FunSuite with Matchers wi
       case (r, s) =>
         val t0 = System.currentTimeMillis()
         queryVecs.foreach { vec =>
-          val q = HashingQuery(field, vec, 100, 1f, model.hash(vec.values, 9), exactFunc, r)
+          val q = HashingQuery(field, vec, 100, 1f, model.hash(vec.values, 9), exactFunc, r, VectorCache.empty)
           val dd = s.search(q, 100)
           dd.scoreDocs should have length 100
         }


### PR DESCRIPTION
Adds a global guava cache for dense vectors and another for sparse vectors.
The main motivation for this is that versions above 7.6.2 use a version of Lucene that introduced higher compression to binary doc values fields. 
So it takes significantly longer to consume the vectors from Lucene to do exact similarity scoring.

The caches are instantiated in the `Elastiknn#getPlugin` method and get woven through the various query-related classes.

Caching is configurable using the parameters below, shown with their default values:
```
elastiknn.cache.enabled=false           # whether to use caching
elastiknn.cache.capacity_mb=512     # capacity limit of each cache in megabytes
elastiknn.cache.ttl_seconds=600       # TTL (expire-after-write) for any entry in each cache
```