### PR TITLE
elastiknn_nearest_neighbors score function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+- Added support for [Function Score Queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html)
+  See the [Common Patterns](https://elastiknn.com/api/#common-patterns) section of the docs.
+---
 - Improved the Python ElastiknnModel's handling of empty query responses (i.e. no results). 
   Previously it threw an exception. Now it will just not populate the ID and distance arrays for that particular query.
 ---

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/ElastiknnPlugin.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/ElastiknnPlugin.scala
@@ -1,7 +1,7 @@
 package com.klibisz.elastiknn
 
 import java.util
-import java.util.Optional
+import java.util.{Collections, Optional}
 
 import com.klibisz.elastiknn.codec.ElastiknnCodecService
 import com.klibisz.elastiknn.mapper.VectorMapper
@@ -10,12 +10,12 @@ import org.elasticsearch.common.settings.{Setting, Settings}
 import org.elasticsearch.index.IndexSettings
 import org.elasticsearch.index.engine.{Engine, EngineConfig, EngineFactory, InternalEngine}
 import org.elasticsearch.index.mapper.Mapper
-import org.elasticsearch.plugins.SearchPlugin.QuerySpec
+import org.elasticsearch.plugins.SearchPlugin.{QuerySpec, ScoreFunctionSpec}
 import org.elasticsearch.plugins._
 
 class ElastiknnPlugin(settings: Settings) extends Plugin with SearchPlugin with MapperPlugin with EnginePlugin {
 
-  override def getQueries: util.List[SearchPlugin.QuerySpec[_]] = util.Arrays.asList(
+  override def getQueries: util.List[SearchPlugin.QuerySpec[_]] = Collections.singletonList(
     new QuerySpec(KnnQueryBuilder.NAME, KnnQueryBuilder.Reader, KnnQueryBuilder.Parser)
   )
 
@@ -27,9 +27,12 @@ class ElastiknnPlugin(settings: Settings) extends Plugin with SearchPlugin with 
     }
   }
 
-  override def getSettings: util.List[Setting[_]] = util.List.of[Setting[_]](
-    ElastiknnPlugin.Settings.elastiknn
-  )
+  override def getSettings: util.List[Setting[_]] = Collections.singletonList(ElastiknnPlugin.Settings.elastiknn)
+
+  override def getScoreFunctions: util.List[SearchPlugin.ScoreFunctionSpec[_]] =
+    Collections.singletonList(
+      new ScoreFunctionSpec(KnnScoreFunctionBuilder.NAME, KnnScoreFunctionBuilder.Reader, KnnScoreFunctionBuilder.Parser)
+    )
 
   override def getEngineFactory(indexSettings: IndexSettings): Optional[EngineFactory] = {
     if (indexSettings.getValue(ElastiknnPlugin.Settings.elastiknn)) Optional.of {

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/ExactQuery.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/ExactQuery.scala
@@ -27,7 +27,7 @@ object ExactQuery {
           simFunc(queryVec, storedVec)
         }
         override def explainScore(docId: Int, subQueryScore: Explanation): Explanation =
-          Explanation.`match`(100, s"Elastiknn exact query")
+          Explanation.`match`(score(docId, subQueryScore.getValue.floatValue()), s"Elastiknn exact query")
       }
     }
 

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
@@ -4,7 +4,7 @@ import java.util.Objects
 
 import com.klibisz.elastiknn.ELASTIKNN_NAME
 import com.klibisz.elastiknn.ElastiknnException.ElastiknnIllegalArgumentException
-import com.klibisz.elastiknn.api.Vec
+import com.klibisz.elastiknn.api.{NearestNeighborsQuery, Vec}
 import org.apache.lucene.index.LeafReaderContext
 import org.apache.lucene.search.{Explanation, Query, ScoreMode, Weight}
 import org.elasticsearch.common.io.stream.{StreamInput, StreamOutput, Writeable}
@@ -22,7 +22,10 @@ object KnnScoreFunctionBuilder {
 
   object Reader extends Writeable.Reader[KnnScoreFunctionBuilder] {
     override def read(in: StreamInput): KnnScoreFunctionBuilder = {
-      val knnQueryBuilder = KnnQueryBuilder.Reader.read(in)
+      in.readOptionalFloat() // read weight
+      val s = in.readString()
+      val query = KnnQueryBuilder.decodeB64[NearestNeighborsQuery](s)
+      val knnQueryBuilder = KnnQueryBuilder(query)
       new KnnScoreFunctionBuilder(knnQueryBuilder)
     }
   }

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
@@ -1,11 +1,20 @@
 package com.klibisz.elastiknn.query
 
+import java.util.Objects
+
 import com.klibisz.elastiknn.ELASTIKNN_NAME
+import com.klibisz.elastiknn.ElastiknnException.ElastiknnIllegalArgumentException
+import com.klibisz.elastiknn.api.Vec
+import org.apache.lucene.index.LeafReaderContext
+import org.apache.lucene.search.{Explanation, Query, ScoreMode, Weight}
 import org.elasticsearch.common.io.stream.{StreamInput, StreamOutput, Writeable}
-import org.elasticsearch.common.lucene.search.function.ScoreFunction
+import org.elasticsearch.common.lucene.search.function
+import org.elasticsearch.common.lucene.search.function.{CombineFunction, LeafScoreFunction, ScoreFunction}
 import org.elasticsearch.common.xcontent.{ToXContent, XContentBuilder, XContentParser}
 import org.elasticsearch.index.query.QueryShardContext
 import org.elasticsearch.index.query.functionscore.{ScoreFunctionBuilder, ScoreFunctionParser}
+
+import scala.util.{Failure, Success, Try}
 
 object KnnScoreFunctionBuilder {
 
@@ -13,28 +22,78 @@ object KnnScoreFunctionBuilder {
 
   object Reader extends Writeable.Reader[KnnScoreFunctionBuilder] {
     override def read(in: StreamInput): KnnScoreFunctionBuilder = {
-      ???
+      val knnQueryBuilder = KnnQueryBuilder.Reader.read(in)
+      new KnnScoreFunctionBuilder(knnQueryBuilder)
     }
   }
 
   object Parser extends ScoreFunctionParser[KnnScoreFunctionBuilder] {
     override def fromXContent(parser: XContentParser): KnnScoreFunctionBuilder = {
-      ???
+      val knnQueryBuilder = KnnQueryBuilder.Parser.fromXContent(parser)
+      new KnnScoreFunctionBuilder(knnQueryBuilder)
+    }
+  }
+
+  class ScoreFunction private (val weight: Weight) extends function.ScoreFunction(CombineFunction.REPLACE) {
+
+    override def getLeafScoreFunction(ctx: LeafReaderContext): LeafScoreFunction = {
+      val scorer = weight.scorer(ctx)
+      val iterator = scorer.iterator()
+      new LeafScoreFunction {
+        override def score(docId: Int, subQueryScore: Float): Double = {
+          iterator.advance(docId)
+          scorer.score()
+        }
+        override def explainScore(docId: Int, subQueryScore: Explanation): Explanation = {
+          Explanation.`match`(
+            score(docId, subQueryScore.getValue.floatValue()).toFloat,
+            s"$NAME score function"
+          )
+        }
+      }
+    }
+
+    override def needsScores(): Boolean = false
+
+    override def doEquals(other: function.ScoreFunction): Boolean = other match {
+      case f: KnnScoreFunctionBuilder.ScoreFunction => weight == f.weight
+      case _                                        => false
+    }
+
+    override def doHashCode(): Int = Objects.hash(weight)
+  }
+
+  object ScoreFunction {
+    def apply(knnQueryBuilder: KnnQueryBuilder, context: QueryShardContext): Try[ScoreFunction] = {
+      knnQueryBuilder.query.vec match {
+        case _: Vec.Indexed =>
+          Failure(new ElastiknnIllegalArgumentException(s"Score functions with indexed vectors are not yet supported"))
+        case _ =>
+          val query: Query = knnQueryBuilder.doToQuery(context)
+          val weight = query.createWeight(context.searcher(), ScoreMode.TOP_SCORES, 1f)
+          Success(new ScoreFunction(weight))
+      }
     }
   }
 
 }
 
-final case class KnnScoreFunctionBuilder() extends ScoreFunctionBuilder[KnnScoreFunctionBuilder] {
-  override def doWriteTo(out: StreamOutput): Unit = ???
+final case class KnnScoreFunctionBuilder(knnQueryBuilder: KnnQueryBuilder) extends ScoreFunctionBuilder[KnnScoreFunctionBuilder] {
+  override def doWriteTo(out: StreamOutput): Unit = {
+    out.writeString(KnnQueryBuilder.encodeB64(knnQueryBuilder.query))
+  }
 
-  override def getName: String = ???
+  override def getName: String = KnnScoreFunctionBuilder.NAME
 
-  override def doXContent(builder: XContentBuilder, params: ToXContent.Params): Unit = ???
+  override def doXContent(builder: XContentBuilder, params: ToXContent.Params): Unit = {
+    ()
+  }
 
-  override def doEquals(functionBuilder: KnnScoreFunctionBuilder): Boolean = ???
+  override def doEquals(other: KnnScoreFunctionBuilder): Boolean =
+    other.knnQueryBuilder.query == knnQueryBuilder.query
 
-  override def doHashCode(): Int = ???
+  override def doHashCode(): Int = Objects.hash(knnQueryBuilder)
 
-  override def doToFunction(context: QueryShardContext): ScoreFunction = ???
+  override def doToFunction(context: QueryShardContext): ScoreFunction =
+    KnnScoreFunctionBuilder.ScoreFunction(knnQueryBuilder, context).get
 }

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
@@ -1,0 +1,40 @@
+package com.klibisz.elastiknn.query
+
+import com.klibisz.elastiknn.ELASTIKNN_NAME
+import org.elasticsearch.common.io.stream.{StreamInput, StreamOutput, Writeable}
+import org.elasticsearch.common.lucene.search.function.ScoreFunction
+import org.elasticsearch.common.xcontent.{ToXContent, XContentBuilder, XContentParser}
+import org.elasticsearch.index.query.QueryShardContext
+import org.elasticsearch.index.query.functionscore.{ScoreFunctionBuilder, ScoreFunctionParser}
+
+object KnnScoreFunctionBuilder {
+
+  val NAME: String = s"${ELASTIKNN_NAME}_nearest_neighbors"
+
+  object Reader extends Writeable.Reader[KnnScoreFunctionBuilder] {
+    override def read(in: StreamInput): KnnScoreFunctionBuilder = {
+      ???
+    }
+  }
+
+  object Parser extends ScoreFunctionParser[KnnScoreFunctionBuilder] {
+    override def fromXContent(parser: XContentParser): KnnScoreFunctionBuilder = {
+      ???
+    }
+  }
+
+}
+
+final case class KnnScoreFunctionBuilder() extends ScoreFunctionBuilder[KnnScoreFunctionBuilder] {
+  override def doWriteTo(out: StreamOutput): Unit = ???
+
+  override def getName: String = ???
+
+  override def doXContent(builder: XContentBuilder, params: ToXContent.Params): Unit = ???
+
+  override def doEquals(functionBuilder: KnnScoreFunctionBuilder): Boolean = ???
+
+  override def doHashCode(): Int = ???
+
+  override def doToFunction(context: QueryShardContext): ScoreFunction = ???
+}

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/KnnScoreFunctionBuilder.scala
@@ -76,7 +76,7 @@ object KnnScoreFunctionBuilder {
     }
   }
 
-  class ScoreFunction private (val weight: Weight) extends function.ScoreFunction(CombineFunction.REPLACE) {
+  class ScoreFunction private (val weight: Weight) extends function.ScoreFunction(CombineFunction.MULTIPLY) {
 
     override def getLeafScoreFunction(ctx: LeafReaderContext): LeafScoreFunction = {
       val scorer = weight.scorer(ctx)

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/NearestNeighborsQuerySpec.scala
@@ -16,8 +16,6 @@ import scala.concurrent.Future
 import scala.util.Random
 import scala.util.hashing.MurmurHash3
 
-import scala.util.Random
-
 class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspectors with ElasticAsyncClient with SilentMatchers {
 
   // https://github.com/alexklibisz/elastiknn/issues/60
@@ -73,7 +71,7 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
   }
 
   // https://github.com/alexklibisz/elastiknn/issues/97
-  describe("Query with filter on another field") {
+  describe("Usage in query rescorer") {
     implicit val rng: Random = new Random(0)
     val indexPrefix = "issue-97"
 
@@ -133,6 +131,86 @@ class NearestNeighborsQuerySpec extends AsyncFunSpec with Matchers with Inspecto
            |      },
            |      "query_weight": 0,
            |      "rescore_query_weight": 1
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+      for {
+        _ <- deleteIfExists(index)
+        _ <- eknn.createIndex(index)
+        _ <- eknn.execute(putMapping(index).rawSource(rawMapping))
+        _ <- Future.traverse(corpus.grouped(100)) { batch =>
+          val reqs = batch.map {
+            case (id, vec, color) =>
+              val docSource = s"""{ "vec": ${ElasticsearchCodec.nospaces(vec)}, "color": "$color" }"""
+              indexInto(index).id(id).source(docSource)
+          }
+          eknn.execute(bulk(reqs))
+        }
+        _ <- eknn.execute(refreshIndex(index))
+        res <- eknn.execute(search(index).source(rawQuery))
+      } yield {
+        res.result.hits.hits.length shouldBe numBlue
+        res.result.hits.hits.map(_.id).toSet shouldBe corpus.filter(_._3 == "blue").map(_._1).toSet
+      }
+    }
+  }
+
+  describe("Usage in function score query") {
+    implicit val rng: Random = new Random(0)
+    val indexPrefix = "issue-97b"
+
+    // Generate a corpus of docs. Small number of the them have color blue, rest have color green.
+    val dims = 10
+    val numTotal = 1000
+    val numBlue = 100
+    val corpus: Seq[(String, Vec.DenseFloat, String)] =
+      (0 until numTotal).map(i => (s"v$i", Vec.DenseFloat.random(dims), if (i < numBlue) "blue" else "green"))
+
+    // Make sure there are fewer candidates than the whole corpus. This ensures the filter is executed before the knn.
+    val candidates = numBlue
+
+    // Test with multiple mappings/queries.
+    val queryVec = Vec.DenseFloat.random(dims)
+    val mappingsAndQueries = Seq(
+      Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+        NearestNeighborsQuery.L2Lsh("vec", candidates, vec = queryVec)
+      ),
+      Mapping.AngularLsh(dims, 40, 1) -> Seq(
+        NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
+        NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+        NearestNeighborsQuery.AngularLsh("vec", candidates, queryVec)
+      )
+    )
+
+    for {
+      (mapping, queries) <- mappingsAndQueries
+      query: NearestNeighborsQuery <- queries
+      index = s"$indexPrefix-${MurmurHash3.orderedHash(Seq(mapping, query), 0).toString}"
+    } it(s"filters with mapping [${mapping}] and query [${query}] in index [$index]") {
+      val rawMapping =
+        s"""
+           |{
+           |  "properties": {
+           |    "vec": ${ElasticsearchCodec.mapping(mapping).noSpaces},
+           |    "color": {
+           |      "type": "keyword"
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+      val rawQuery =
+        s"""
+           |{
+           |  "size": $numBlue,
+           |  "query": {
+           |    "function_score": {
+           |      "query": {
+           |        "term": { "color": "blue" }
+           |      },
+           |      "elastiknn_nearest_neighbors": ${ElasticsearchCodec.nospaces(query)}
            |    }
            |  }
            |}


### PR DESCRIPTION
This enables using elastiknn in function score queries:

```
{
  "size": 3,
  "query": {
    "function_score": {
      "query": {
        "term": {
          "color": "blue"
        }
      },
      "elastiknn_nearest_neighbors": {
        "field": "vec",
        "similarity": "angular",
        "model": "exact",
        "vec": {
          "values": [
            0.1,
            0.2,
            0.3
          ]
        }
      }
    }
  }
}
```