### PR TITLE
Bump ES from 7.9.2 to 7.9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ run/debug:
  		-Dtests.es.thread_pool.search.size=1 -Drun.distribution=basic --debug-jvm
 
 run/kibana:
-	docker run --network host -e ELASTICSEARCH_HOSTS=http://localhost:9200 -p 5601:5601 -d --rm kibana:7.9.2
+	docker run --network host -e ELASTICSEARCH_HOSTS=http://localhost:9200 -p 5601:5601 -d --rm kibana:7.9.3
 	docker ps | grep kibana
 
 run/demo: .mk/gradle-publish-local .mk/example-demo-sbt-docker-stage .mk/example-demo-sbt-docker-stage .mk/vm-max-map-count

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        esVersion = '7.9.2'
+        esVersion = '7.9.3'
         luceneVersion = '8.6.2'
         circeVersion= '0.13.0'
         scalaShortVersion = '2.12'

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- Bumped Elasticsearch version to 7.9.3.
+---
 - Fixed the function score query implementation. The first pass was kind of buggy for exact queries and totally wrong for approximate queries.
 - Addressed a perplexing edge case that was causing an out-of-bounds exception in the MatchHashesAndScoreQuery. 
 ---

--- a/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Aggregate.scala
+++ b/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Aggregate.scala
@@ -20,12 +20,7 @@ import zio.stream.ZSink
   */
 object Aggregate extends App {
 
-  final case class Params(resultsPrefix: String = "",
-                          aggregateKey: String = "",
-                          bucket: String = "",
-                          s3Url: Option[String] = None,
-                          airtableUrl: Option[String] = None,
-                          airtableToken: Option[String] = None)
+  final case class Params(resultsPrefix: String = "", aggregateKey: String = "", bucket: String = "", s3Url: Option[String] = None)
 
   private val parser = new scopt.OptionParser[Params]("Aggregate results into a single file") {
     override def showUsageOnError: Option[Boolean] = Some(true)

--- a/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/LocalBenchmark.scala
+++ b/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/LocalBenchmark.scala
@@ -48,9 +48,7 @@ object LocalBenchmark extends App {
           "results",
           "results/aggregate.csv",
           bucket,
-          Some(s3Url),
-          Some("https://api.airtable.com/v0/appmy9gAptPsjo4M7/Results"),
-          sys.env.get("AIRTABLE_API_KEY")
+          Some(s3Url)
         ))
     } yield ()
     pipeline.exitCode

--- a/elastiknn-plugin/Dockerfile
+++ b/elastiknn-plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.9.2-amd64
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.9.3-amd64
 
 RUN yum -y install epel-release htop
 


### PR DESCRIPTION
Also removes some benchmarking cruft.

Benchmarking results look solid: 13.14 q/s for exact fashion-mnist, 222.22 q/s for L2 LSH.