### PR TITLE
Better error for function score query with stored vector.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,2 @@
-version = "2.5.2"
+version = "2.4.0"
 maxColumn = 140

--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,7 @@ configure(testing, List.of(scalaProjectConfig, {
         implementation "org.elasticsearch:elasticsearch:${esVersion}"
         implementation "com.storm-enroute:scalameter_${scalaShortVersion}:0.19"
         implementation "org.scalanlp:breeze_${scalaShortVersion}:1.0"
+        implementation "com.klibisz.futil:futil_${scalaShortVersion}:0.1.2-PRE0-SNAPSHOT"
         testRuntime 'org.pegdown:pegdown:1.4.2'
         testRuntime 'com.vladsch.flexmark:flexmark-all:0.35.10'
         implementation "org.scala-lang:scala-library:${scalaFullVersion}"

--- a/elastiknn-client-elastic4s/src/main/scala/com/klibisz/elastiknn/client/ElastiknnClient.scala
+++ b/elastiknn-client-elastic4s/src/main/scala/com/klibisz/elastiknn/client/ElastiknnClient.scala
@@ -85,7 +85,8 @@ trait ElastiknnClient[F[_]] extends AutoCloseable {
             h.copy(id = h.fields.get(storedIdField) match {
               case Some(List(id: String)) => id
               case _                      => ""
-            }))
+            })
+          )
           sr.copy(hits = sr.hits.copy(hits = hitsWithIds))
         }
       }
@@ -100,12 +101,11 @@ object ElastiknnClient {
   final case class StrictFailureException(message: String, cause: Throwable = None.orNull) extends RuntimeException(message, cause)
 
   def futureClient(host: String = "localhost", port: Int = 9200, strictFailure: Boolean = true, timeoutMillis: Int = 30000)(
-      implicit ec: ExecutionContext): ElastiknnFutureClient = {
+      implicit ec: ExecutionContext
+  ): ElastiknnFutureClient = {
     val rc: RestClient = RestClient
       .builder(new HttpHost(host, port))
-      .setRequestConfigCallback(
-        (requestConfigBuilder: RequestConfig.Builder) => requestConfigBuilder.setSocketTimeout(timeoutMillis)
-      )
+      .setRequestConfigCallback((requestConfigBuilder: RequestConfig.Builder) => requestConfigBuilder.setSocketTimeout(timeoutMillis))
       .build()
     val jc: JavaClient = new JavaClient(rc)
     new ElastiknnFutureClient {
@@ -119,7 +119,8 @@ object ElastiknnClient {
             case Left(ex) => Future.failed(ex)
             case Right(_) => Future.successful(res)
           }
-        } else future
+        }
+        else future
       }
 
       override def toString: String = s"${ElastiknnClient.getClass.getSimpleName} connected to $host:$port"
@@ -135,22 +136,26 @@ object ElastiknnClient {
         bulkResponseItems.head.error match {
           case Some(err) =>
             Some(
-              ElasticError(err.`type`,
-                           err.reason,
-                           Some(err.index_uuid),
-                           Some(err.index),
-                           Some(err.shard.toString),
-                           Seq.empty,
-                           None,
-                           None,
-                           None,
-                           Seq.empty))
+              ElasticError(
+                err.`type`,
+                err.reason,
+                Some(err.index_uuid),
+                Some(err.index),
+                Some(err.shard.toString),
+                Seq.empty,
+                None,
+                None,
+                None,
+                Seq.empty
+              )
+            )
           case None => findBulkError(bulkResponseItems.tail, acc)
         }
     if (res.isError) {
-      Left(StrictFailureException(s"Returned error response [$res] for request [$req].", res.error.asException))
-    } else if (res.status >= 300) Left(StrictFailureException(s"Returned non-200 response [$res] for request [$req]."))
-    else
+      Left(res.error.asException)
+    } else if (res.status >= 300) {
+      Left(StrictFailureException(s"Returned non-200 response [$res] for request [$req]."))
+    } else
       res.result match {
         case bulkResponse: BulkResponse if bulkResponse.hasFailures =>
           findBulkError(bulkResponse.items) match {

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/DocsWithMissingVectorsSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/DocsWithMissingVectorsSuite.scala
@@ -4,11 +4,11 @@ import com.klibisz.elastiknn.api._
 import com.klibisz.elastiknn.client.ElastiknnRequests
 import com.klibisz.elastiknn.testing.{ElasticAsyncClient, SilentMatchers}
 import com.sksamuel.elastic4s.ElasticDsl._
-import org.scalatest.{Inspectors, _}
+import futil.Futil
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Inspectors, _}
 
-import scala.concurrent.Future
 import scala.util.Random
 
 class DocsWithMissingVectorsSuite extends AsyncFunSuite with Matchers with Inspectors with ElasticAsyncClient with SilentMatchers {
@@ -39,7 +39,7 @@ class DocsWithMissingVectorsSuite extends AsyncFunSuite with Matchers with Inspe
       _ <- deleteIfExists(index)
       _ <- eknn.createIndex(index)
       _ <- eknn.execute(putMapping(index).rawSource(mappingJsonString))
-      _ <- Future.traverse((0 until numDocs).grouped(500)) { ids =>
+      _ <- Futil.traverseSerial((0 until numDocs).grouped(500)) { ids =>
         val reqs = ids.map { i =>
           if (i % 2 == 0) ElastiknnRequests.index(index, vecField, if (i == 0) v0 else Vec.DenseFloat.random(dims), idField, s"v$i")
           else indexInto(index).id(s"v$i").fields(Map(idField -> s"v$i"))

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MixedIndexSearchDeleteSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MixedIndexSearchDeleteSuite.scala
@@ -3,6 +3,7 @@ package com.klibisz.elastiknn.query
 import com.klibisz.elastiknn.api._
 import com.klibisz.elastiknn.testing._
 import com.sksamuel.elastic4s.ElasticDsl._
+import futil.Futil
 import org.scalatest._
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -36,7 +37,7 @@ class MixedIndexSearchDeleteSuite extends AsyncFunSuite with Matchers with Inspe
 
         // Delete the top five vectors.
         deletedIdxs = s1.result.hits.hits.take(5).map(_.id.drop(1).toInt).toSeq
-        _ <- Future.traverse(deletedIdxs.map(ids.apply).map(deleteById(index, _)))(eknn.execute(_))
+        _ <- Futil.traverseParN(8)(deletedIdxs.map(ids.apply).map(deleteById(index, _)))(eknn.execute(_))
         _ <- eknn.execute(refreshIndex(index))
         c2 <- eknn.execute(count(index))
         _ = c2.result.count shouldBe (corpus.length - deletedIdxs.length)

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/QueryRescorerSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/QueryRescorerSuite.scala
@@ -3,11 +3,11 @@ package com.klibisz.elastiknn.query
 import com.klibisz.elastiknn.api._
 import com.klibisz.elastiknn.testing.ElasticAsyncClient
 import com.sksamuel.elastic4s.ElasticDsl._
+import futil.Futil
 import org.scalatest._
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.Future
 import scala.util.Random
 import scala.util.hashing.MurmurHash3
 
@@ -81,7 +81,7 @@ class QueryRescorerSuite extends AsyncFunSuite with Matchers with Inspectors wit
       _ <- deleteIfExists(index)
       _ <- eknn.createIndex(index)
       _ <- eknn.execute(putMapping(index).rawSource(rawMapping))
-      _ <- Future.traverse(corpus.grouped(100)) { batch =>
+      _ <- Futil.traverseSerial(corpus.grouped(100)) { batch =>
         val reqs = batch.map {
           case (id, vec, color) =>
             val docSource = s"""{ "vec": ${ElasticsearchCodec.nospaces(vec)}, "color": "$color" }"""


### PR DESCRIPTION
- Function score queries cannot support queries with stored vectors.
  There's no place where we could make an async call to fetch the stored vector.
  Added an error message that communicates this more explicitly.
- Added a test for the new error message.
- Minor change in client error handling: don't wrap an exception in a StrictFailureException.
- Started using Futil for async control in some of the tests.
- Scalafmted a few files.