### PR TITLE
Use git commits instead of changelog.md in release

### DIFF
--- a/.github/scripts/latestchanges.py
+++ b/.github/scripts/latestchanges.py
@@ -1,4 +1,0 @@
-import sys
-for l in sys.stdin:
-    if l == '---\n': break
-    sys.stdout.write(l)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Release Credentials
         env:
           GPG_SECRET_B64: ${{ secrets.GPG_SECRET_B64 }}
@@ -97,13 +99,17 @@ jobs:
           SSH_CONFIG_B64: ${{ secrets.SSH_CONFIG_B64 }}
           SSH_IDRSA_B64: ${{ secrets.SSH_IDRSA_B64 }}
         run: ./.github/scripts/setup-env.sh
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 14
       - run: |
-          sudo snap install task --classic
-          sudo snap install hub --classic
-          python3 -m pip install setuptools
+          git --no-pager branch
+          git --no-pager tag
+          git --no-pager log origin/master...HEAD --format='- %h: %s'
+      # - uses: actions/setup-java@v1
+      #   with:
+      #     java-version: 14
+      # - run: |
+      #     sudo snap install task --classic
+      #     sudo snap install hub --classic
+      #     python3 -m pip install setuptools
       # - name: Publish to PyPi
       #   run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
       # - name: Publish JVM Libraries from PR
@@ -112,16 +118,15 @@ jobs:
       # - name: Publish JVM Libraries from Master
       #   if: github.event_name == 'push'
       #   run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
-      - name: Publish Plugin from PR
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: task jvm:plugin:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
-      - name: Publish Plugin from Master
-        if: github.event_name == 'push'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./.github/scripts/delete-snapshot-releases.sh
-          task jvm:plugin:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
-      
+      # - name: Publish Plugin from PR
+      #   if: github.event_name == 'pull_request'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: task jvm:plugin:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
+      # - name: Publish Plugin from Master
+      #   if: github.event_name == 'push'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     ./.github/scripts/delete-snapshot-releases.sh
+      #     task jvm:plugin:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,14 @@ jobs:
           sudo snap install task --classic
           sudo snap install hub --classic
           python3 -m pip install setuptools
-      - name: Publish to PyPi
-        run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
-      - name: Publish JVM Libraries from PR
-        if: github.event_name == 'pull_request'
-        run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
-      - name: Publish JVM Libraries from Master
-        if: github.event_name == 'push'
-        run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
+      # - name: Publish to PyPi
+      #   run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
+      # - name: Publish JVM Libraries from PR
+      #   if: github.event_name == 'pull_request'
+      #   run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
+      # - name: Publish JVM Libraries from Master
+      #   if: github.event_name == 'push'
+      #   run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
       - name: Publish Plugin from PR
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,71 +16,71 @@ jobs:
     steps:
       - run: echo $GITHUB_CONTEXT
   
-  # test-jvm:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-java@v1
-  #       with:
-  #         java-version: 14
-  #     - run: sudo snap install task --classic
-  #     - name: Compile
-  #       run: task jvm:compile
-  #     - name: Docs
-  #       run: task jvm:docs
-  #     - name: Publish Local
-  #       run: task jvm:libraries:publish:local
-  #     - name: Run Cluster
-  #       run: task cluster:run
-  #     - name: Test
-  #       run: task jvm:test
-  #     - name: Cluster Logs
-  #       if: failure()
-  #       run: task cluster:logs
+  test-jvm:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - run: sudo snap install task --classic
+      - name: Compile
+        run: task jvm:compile
+      - name: Docs
+        run: task jvm:docs
+      - name: Publish Local
+        run: task jvm:libraries:publish:local
+      - name: Run Cluster
+        run: task cluster:run
+      - name: Test
+        run: task jvm:test
+      - name: Cluster Logs
+        if: failure()
+        run: task cluster:logs
       
-  # test-python:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-java@v1
-  #       with:
-  #         java-version: 14
-  #     - run: sudo snap install task --classic
-  #     - name: Docs
-  #       run: task py:docs
-  #     - name: Publish Local
-  #       run: task jvm:libraries:publish:local
-  #     - name: Run Cluster
-  #       run: task cluster:run
-  #     - name: Test
-  #       run: task py:test
-  #     - name: Cluster Logs
-  #       if: failure()
-  #       run: task cluster:logs
+  test-python:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - run: sudo snap install task --classic
+      - name: Docs
+        run: task py:docs
+      - name: Publish Local
+        run: task jvm:libraries:publish:local
+      - name: Run Cluster
+        run: task cluster:run
+      - name: Test
+        run: task py:test
+      - name: Cluster Logs
+        if: failure()
+        run: task cluster:logs
 
-  # build-examples:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: sudo snap install task --classic
-  #     - uses: olafurpg/setup-scala@v10
-  #       with:
-  #         java-version: 14
-  #     - name: Build SBT client example
-  #       run: |
-  #         task jvm:libraries:publish:local
-  #         cd examples/scala-sbt-client-usage && sbt -batch run
+  build-examples:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo snap install task --classic
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: 14
+      - name: Build SBT client example
+        run: |
+          task jvm:libraries:publish:local
+          cd examples/scala-sbt-client-usage && sbt -batch run
 
-  # build-jekyll-site:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-ruby@v1
-  #       with:
-  #         ruby-version: '2.6'
-  #     - run: sudo snap install task --classic
-  #     - name: Compile Jekyll Site
-  #       run: "task docs:compile"
+  build-jekyll-site:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - run: sudo snap install task --classic
+      - name: Compile Jekyll Site
+        run: "task docs:compile"
 
   # Ideally the snapshot release would run only if the tests pass, but right now
   # there's no way to make a job conditional on another job.
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        # with:
-        #   fetch-depth: 0
+        with:
+          fetch-depth: 0 # Needed for git-based changelog.
       - name: Setup Release Credentials
         env:
           GPG_SECRET_B64: ${{ secrets.GPG_SECRET_B64 }}
@@ -106,14 +106,14 @@ jobs:
           sudo snap install task --classic
           sudo snap install hub --classic
           python3 -m pip install setuptools
-      # - name: Publish to PyPi
-      #   run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
-      # - name: Publish JVM Libraries from PR
-      #   if: github.event_name == 'pull_request'
-      #   run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
-      # - name: Publish JVM Libraries from Master
-      #   if: github.event_name == 'push'
-      #   run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
+      - name: Publish to PyPi
+        run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
+      - name: Publish JVM Libraries from PR
+        if: github.event_name == 'pull_request'
+        run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
+      - name: Publish JVM Libraries from Master
+        if: github.event_name == 'push'
+        run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
       - name: Publish Plugin from PR
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,17 +99,13 @@ jobs:
           SSH_CONFIG_B64: ${{ secrets.SSH_CONFIG_B64 }}
           SSH_IDRSA_B64: ${{ secrets.SSH_IDRSA_B64 }}
         run: ./.github/scripts/setup-env.sh
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 14
       - run: |
-          git --no-pager branch
-          git --no-pager tag
-          git --no-pager log origin/master...HEAD --format='- %h: %s'
-      # - uses: actions/setup-java@v1
-      #   with:
-      #     java-version: 14
-      # - run: |
-      #     sudo snap install task --classic
-      #     sudo snap install hub --classic
-      #     python3 -m pip install setuptools
+          sudo snap install task --classic
+          sudo snap install hub --classic
+          python3 -m pip install setuptools
       # - name: Publish to PyPi
       #   run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
       # - name: Publish JVM Libraries from PR
@@ -118,15 +114,15 @@ jobs:
       # - name: Publish JVM Libraries from Master
       #   if: github.event_name == 'push'
       #   run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
-      # - name: Publish Plugin from PR
-      #   if: github.event_name == 'pull_request'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: task jvm:plugin:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
-      # - name: Publish Plugin from Master
-      #   if: github.event_name == 'push'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     ./.github/scripts/delete-snapshot-releases.sh
-      #     task jvm:plugin:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
+      - name: Publish Plugin from PR
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: task jvm:plugin:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
+      - name: Publish Plugin from Master
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./.github/scripts/delete-snapshot-releases.sh
+          task jvm:plugin:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,71 +16,71 @@ jobs:
     steps:
       - run: echo $GITHUB_CONTEXT
   
-  test-jvm:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 14
-      - run: sudo snap install task --classic
-      - name: Compile
-        run: task jvm:compile
-      - name: Docs
-        run: task jvm:docs
-      - name: Publish Local
-        run: task jvm:libraries:publish:local
-      - name: Run Cluster
-        run: task cluster:run
-      - name: Test
-        run: task jvm:test
-      - name: Cluster Logs
-        if: failure()
-        run: task cluster:logs
+  # test-jvm:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-java@v1
+  #       with:
+  #         java-version: 14
+  #     - run: sudo snap install task --classic
+  #     - name: Compile
+  #       run: task jvm:compile
+  #     - name: Docs
+  #       run: task jvm:docs
+  #     - name: Publish Local
+  #       run: task jvm:libraries:publish:local
+  #     - name: Run Cluster
+  #       run: task cluster:run
+  #     - name: Test
+  #       run: task jvm:test
+  #     - name: Cluster Logs
+  #       if: failure()
+  #       run: task cluster:logs
       
-  test-python:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 14
-      - run: sudo snap install task --classic
-      - name: Docs
-        run: task py:docs
-      - name: Publish Local
-        run: task jvm:libraries:publish:local
-      - name: Run Cluster
-        run: task cluster:run
-      - name: Test
-        run: task py:test
-      - name: Cluster Logs
-        if: failure()
-        run: task cluster:logs
+  # test-python:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-java@v1
+  #       with:
+  #         java-version: 14
+  #     - run: sudo snap install task --classic
+  #     - name: Docs
+  #       run: task py:docs
+  #     - name: Publish Local
+  #       run: task jvm:libraries:publish:local
+  #     - name: Run Cluster
+  #       run: task cluster:run
+  #     - name: Test
+  #       run: task py:test
+  #     - name: Cluster Logs
+  #       if: failure()
+  #       run: task cluster:logs
 
-  build-examples:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo snap install task --classic
-      - uses: olafurpg/setup-scala@v10
-        with:
-          java-version: 14
-      - name: Build SBT client example
-        run: |
-          task jvm:libraries:publish:local
-          cd examples/scala-sbt-client-usage && sbt -batch run
+  # build-examples:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: sudo snap install task --classic
+  #     - uses: olafurpg/setup-scala@v10
+  #       with:
+  #         java-version: 14
+  #     - name: Build SBT client example
+  #       run: |
+  #         task jvm:libraries:publish:local
+  #         cd examples/scala-sbt-client-usage && sbt -batch run
 
-  build-jekyll-site:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.6'
-      - run: sudo snap install task --classic
-      - name: Compile Jekyll Site
-        run: "task docs:compile"
+  # build-jekyll-site:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-ruby@v1
+  #       with:
+  #         ruby-version: '2.6'
+  #     - run: sudo snap install task --classic
+  #     - name: Compile Jekyll Site
+  #       run: "task docs:compile"
 
   # Ideally the snapshot release would run only if the tests pass, but right now
   # there's no way to make a job conditional on another job.
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        # with:
+        #   fetch-depth: 0
       - name: Setup Release Credentials
         env:
           GPG_SECRET_B64: ${{ secrets.GPG_SECRET_B64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
           java-version: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/setup-java@v1
         with:
           java-version: 14

--- a/Taskfile.jvm.yml
+++ b/Taskfile.jvm.yml
@@ -67,9 +67,9 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - "git --no-pager log {{ .VERSION }}...HEAD --format='- %h: %s%n%b%n' >> release.md"
-      # - hub release delete {{ .VERSION }} || true
-      # - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
+      - "git --no-pager log {{ .VERSION }}...HEAD --format='- %h: %s' >> release.md"
+      - hub release delete {{ .VERSION }} || true
+      - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
   plugin:publish:release:
     desc: Publish an official release to Github
@@ -79,9 +79,8 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      # - git --no-pager log {{ .VERSION }}...HEAD --format='%h: %s%n%b%n' >> $F
-      # - cat changelog.md | python .github/scripts/latestchanges.py >> release.md
-      # - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
+      - "git --no-pager log {{ .VERSION }}...HEAD --format='- %h: %s' >> release.md"
+      - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
   run:gradle:
     desc: Run Elasticsearch using gradle

--- a/Taskfile.jvm.yml
+++ b/Taskfile.jvm.yml
@@ -67,7 +67,7 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - "git --no-pager log {{ .VERSION }}...HEAD --format='- %h: %s' >> release.md"
+      - "git --no-pager log master...HEAD --format='- %h: %s' >> release.md"
       - hub release delete {{ .VERSION }} || true
       - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
@@ -79,7 +79,7 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - "git --no-pager log {{ .VERSION }}...HEAD --format='- %h: %s' >> release.md"
+      - "git --no-pager log master...HEAD --format='- %h: %s' >> release.md"
       - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
   run:gradle:

--- a/Taskfile.jvm.yml
+++ b/Taskfile.jvm.yml
@@ -65,11 +65,11 @@ tasks:
     desc: Publish a snapshot release to Github
     cmds:
       - "{{ .CMD_GRADLE }} assemble"
-      - echo "{{ .VERSION }}" > release.md
+      - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - echo "_snapshot release_" >> release.md
-      - hub release delete {{ .VERSION }} || true
-      - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
+      - "git --no-pager log {{ .VERSION }}...HEAD --format='%h: %s%n%b%n' >> release.md"
+      # - hub release delete {{ .VERSION }} || true
+      # - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
   plugin:publish:release:
     desc: Publish an official release to Github
@@ -79,8 +79,9 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - cat changelog.md | python .github/scripts/latestchanges.py >> release.md
-      - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
+      # - git --no-pager log {{ .VERSION }}...HEAD --format='%h: %s%n%b%n' >> $F
+      # - cat changelog.md | python .github/scripts/latestchanges.py >> release.md
+      # - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
   run:gradle:
     desc: Run Elasticsearch using gradle

--- a/Taskfile.jvm.yml
+++ b/Taskfile.jvm.yml
@@ -67,7 +67,7 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - "git --no-pager log {{ .VERSION }}...HEAD --format='%h: %s%n%b%n' >> release.md"
+      - "git --no-pager log {{ .VERSION }}...HEAD --format='- %h: %s%n%b%n' >> release.md"
       # - hub release delete {{ .VERSION }} || true
       # - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 

--- a/Taskfile.jvm.yml
+++ b/Taskfile.jvm.yml
@@ -67,7 +67,7 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - "git --no-pager log master...HEAD --format='- %h: %s' >> release.md"
+      - "git --no-pager log origin/master...HEAD --format='- %h: %s' >> release.md"
       - hub release delete {{ .VERSION }} || true
       - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
@@ -79,7 +79,7 @@ tasks:
       - "{{ .CMD_GRADLE }} assemble"
       - echo {{ .VERSION }} > release.md
       - echo "" >> release.md
-      - "git --no-pager log master...HEAD --format='- %h: %s' >> release.md"
+      - "git --no-pager log origin/master...HEAD --format='- %h: %s' >> release.md"
       - hub release create -p -F release.md -a elastiknn-plugin/build/distributions/elastiknn-*.zip {{ .VERSION }}
 
   run:gradle:


### PR DESCRIPTION
Instead of maintaining commits _and_ a changelog, just use the commits.