### PR TITLE
Renaming "Angular" to "Cosine" in Plugin and Scala client (Re #277)

### DIFF
--- a/docs/pages/api.md
+++ b/docs/pages/api.md
@@ -311,10 +311,10 @@ PUT /my-index/_mapping
 |5|Number of hash tables. Generally, increasing this value increases recall.|
 |6|Number of hash functions combined to form a single hash value. Generally, increasing this value increases precision.|
 
-### Angular LSH Mapping
+### Cosine LSH Mapping
 
 Uses the [Random Projection algorithm](https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Random_projection)
-to hash and store dense float vectors such that they support approximate Angular similarity queries.
+to hash and store dense float vectors such that they support approximate Cosine similarity queries.
 
 The implementation is influenced by Chapter 3 of [Mining Massive Datasets.](http://www.mmds.org/)
 
@@ -327,7 +327,7 @@ PUT /my-index/_mapping
             "elastiknn": {
                 "dims": 100,                        # 2
                 "model": "lsh",                     # 3
-                "similarity": "angular",            # 4
+                "similarity": "cosine",            # 4
                 "L": 99,                            # 5
                 "k": 1                              # 6
             }
@@ -388,7 +388,7 @@ Uses the model described in [Large-Scale Image Retrieval with Elasticsearch by A
 This model describes a vector by the `k` indices (_positions in the vector_) with the greatest absolute values.
 The intuition is that each index corresponds to some latent concept, and indices with high absolute values carry more 
 information about their respective concepts than those with low absolute values.
-The research for this method has focused mainly on Angular similarity, though the implementation supports Angular, L1, and L2.
+The research for this method has focused mainly on Cosine similarity, though the implementation supports Cosine, L1, and L2.
 
 **An example**
 
@@ -413,7 +413,7 @@ PUT /my-index/_mapping
             "elastiknn": {
                 "dims": 100,                        # 2
                 "model": "permutation_lsh",         # 3
-                "similarity": "angular",            # 4
+                "similarity": "cosine",            # 4
                 "k": 10,                            # 5
                 "repeating": true                   # 6
             }
@@ -427,7 +427,7 @@ PUT /my-index/_mapping
 |1|Vector datatype. Must be dense float vector.|
 |2|Vector dimensionality.|
 |3|Model type.|
-|4|Similarity. Supports angular, l1, and l2|
+|4|Similarity. Supports Cosine, L1, and L2.|
 |5|The number of top indices to pick.|
 |6|Whether or not to repeat the indices proportionally to their rank. See the notes on repeating above.|
 
@@ -451,7 +451,7 @@ GET /my-index/_search
                 "values": [0.1, 0.2, 0.3, ...],               
             },
             "model": "exact",                   # 4
-            "similarity": "angular",            # 5
+            "similarity": "cosine",            # 5
             ...                                 # 6
         }
     }
@@ -470,10 +470,10 @@ GET /my-index/_search
 ### Compatibility of Vector Types and Similarities
 
 Jaccard and Hamming similarity only work with sparse bool vectors. 
-Angular, L1, and L2 similarity only work with dense float vectors. 
+Cosine, L1, and L2 similarity only work with dense float vectors. 
 The following documentation assume this restriction is known.
 
-These restrictions aren't inherent to the types and algorithms, i.e., you could in theory run angular similarity on sparse vectors.
+These restrictions aren't inherent to the types and algorithms, i.e., you could in theory run cosine similarity on sparse vectors.
 The restriction merely reflects the most common patterns and simplifies the implementation.
 
 ### Similarity Scoring
@@ -490,7 +490,7 @@ The exact transformations are described below.
 |:--|:--|:--|
 |Jaccard|N/A|0|1.0|
 |Hamming|N/A|0|1.0|
-|Angular|`cosine similarity + 1`|0|2|
+|Cosine|`cosine similarity + 1`|0|2|
 |L1|`1 / (1 + l1 distance)`|0|1|
 |L2|`1 / (1 + l2 distance)`|0|1|
 
@@ -545,7 +545,7 @@ GET /my-index/_search
                 "values": [0.1, 0.2, 0.3, ...],
             },
             "model": "exact",                       # 2
-            "similarity": "(angular | l1 | l2)",    # 3
+            "similarity": "(cosine | l1 | l2)",    # 3
         }
     }
 }
@@ -664,9 +664,9 @@ GET /my-index/_search
 |5|Number of candidates per segment. See the section on LSH Search Strategy.|
 |6|Set to true to use the more-like-this heuristic to pick a subset of hashes. Generally faster but still experimental.|
 
-### Angular LSH Query
+### Cosine LSH Query
 
-Retrieve dense float vectors based on approximate Angular similarity.
+Retrieve dense float vectors based on approximate Cosine similarity.
 
 ```json
 GET /my-index/_search
@@ -678,7 +678,7 @@ GET /my-index/_search
                 "values": [0.1, 0.2, 0.3, ...]
             },
             "model": "lsh",                        # 3
-            "similarity": "angular",               # 4
+            "similarity": "cosine",               # 4
             "candidates": 50                       # 5
         }
     }
@@ -687,7 +687,7 @@ GET /my-index/_search
 
 |#|Description|
 |:--|:--|
-|1|Indexed field. Must use `lsh` mapping model with `angular` similarity.|
+|1|Indexed field. Must use `lsh` mapping model with `cosine` similarity.|
 |2|Query vector. Must be literal dense float or a pointer to an indexed dense float vector.|
 |3|Model name.|
 |4|Similarity function.|
@@ -744,7 +744,7 @@ GET /my-index/_search
                 "values": [0.1, 0.2, 0.3, ...]
             },
             "model": "permutation_lsh",            # 3
-            "similarity": "angular",               # 4
+            "similarity": "cosine",               # 4
             "candidates": 50                       # 5
         }
     }
@@ -756,7 +756,7 @@ GET /my-index/_search
 |1|Indexed field. Must use `permutation_lsh` mapping to use this query.|
 |2|Query vector. Must be literal dense float or a pointer to an indexed dense float vector.|
 |3|Model name.|
-|4|Similarity function. Supports Angular, L1, and L2.|
+|4|Similarity function. Supports Cosine, L1, and L2.|
 |5|Number of candidates per segment. See the section on LSH Search Strategy.|
 
 ### Model and Query Compatibility
@@ -767,7 +767,7 @@ The opposite is _not_ true: vectors stored using the exact model do not support 
 
 The tables below shows valid model/query combinations. 
 Rows are models and columns are queries. 
-The similarity functions are abbreviated (J: Jaccard, H: Hamming, A: Angular, L1, L2).
+The similarity functions are abbreviated (J: Jaccard, H: Hamming, A: Cosine, L1, L2).
 
 #### elastiknn_sparse_bool_vector
 
@@ -780,10 +780,10 @@ The similarity functions are abbreviated (J: Jaccard, H: Hamming, A: Angular, L1
 
 #### elastiknn_dense_float_vector
 
-|Model / Query                   |Exact         |Angular LSH |L2 LSH |Permutation LSH|
+|Model / Query                   |Exact         |Cosine LSH |L2 LSH |Permutation LSH|
 |:--                             |:--           |:--         |:--    |:--            |
 |Exact (i.e. no model specified) |✔ (A, L1, L2) |x           |x      |x              | 
-|Angular LSH                     |✔ (A, L1, L2) |✔           |x      |x              |
+|Cosine LSH                     |✔ (A, L1, L2) |✔           |x      |x              |
 |L2 LSH                          |✔ (A, L1, L2) |x           |✔      |x              |
 |Permutation LSH                 |✔ (A, L1, L2) |x           |x      |✔              |
 
@@ -813,7 +813,7 @@ GET /my-index/_search
         {
           "elastiknn_nearest_neighbors": {           # 3
             "field": "vec",
-            "similarity": "angular",
+            "similarity": "cosine",
             "model": "exact",
             "vec": {
               "values": [0.1, 0.2, 0.3, ...]

--- a/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/ElasticsearchCodec.scala
+++ b/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/ElasticsearchCodec.scala
@@ -18,9 +18,7 @@ trait ElasticsearchCodec[A] extends Codec[A]
 
 private object Keys {
   val ANGULAR = "angular"
-  val ANGULAR_LSH = "angular_lsh"
   val COSINE = "cosine"
-  val COSINE_LSH = "cosine_lsh"
   val DIMS = "dims"
   val EKNN_DENSE_FLOAT_VECTOR = s"${ELASTIKNN_NAME}_dense_float_vector"
   val EKNN_SPARSE_BOOL_VECTOR = s"${ELASTIKNN_NAME}_sparse_bool_vector"

--- a/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/ElasticsearchCodec.scala
+++ b/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/ElasticsearchCodec.scala
@@ -19,6 +19,8 @@ trait ElasticsearchCodec[A] extends Codec[A]
 private object Keys {
   val ANGULAR = "angular"
   val ANGULAR_LSH = "angular_lsh"
+  val COSINE = "cosine"
+  val COSINE_LSH = "cosine_lsh"
   val DIMS = "dims"
   val EKNN_DENSE_FLOAT_VECTOR = s"${ELASTIKNN_NAME}_dense_float_vector"
   val EKNN_SPARSE_BOOL_VECTOR = s"${ELASTIKNN_NAME}_sparse_bool_vector"
@@ -97,8 +99,9 @@ object ElasticsearchCodec { esc =>
           case HAMMING => Right(Similarity.Hamming)
           case L1      => Right(Similarity.L1)
           case L2      => Right(Similarity.L2)
-          case ANGULAR => Right(Similarity.Angular)
-          case other   => failTypes(SIMILARITY, Seq(JACCARD, HAMMING, L1, L2, ANGULAR), other)
+          case COSINE  => Right(Similarity.Cosine)
+          case ANGULAR => Right(Similarity.Cosine)
+          case other   => failTypes(SIMILARITY, Seq(JACCARD, HAMMING, L1, L2, ANGULAR, COSINE), other)
         }
       } yield sim
     override def apply(a: Similarity): Json =
@@ -107,7 +110,7 @@ object ElasticsearchCodec { esc =>
         case Similarity.Hamming => HAMMING
         case Similarity.L1      => L1
         case Similarity.L2      => L2
-        case Similarity.Angular => ANGULAR
+        case Similarity.Cosine  => COSINE
       }
   }
 
@@ -160,7 +163,7 @@ object ElasticsearchCodec { esc =>
   implicit val mappingSparseIndexed: ESC[Mapping.SparseIndexed] = ElasticsearchCodec(deriveCodec)
   implicit val mappingJaccardLsh: ESC[Mapping.JaccardLsh] = ElasticsearchCodec(deriveCodec)
   implicit val mappingHammingLsh: ESC[Mapping.HammingLsh] = ElasticsearchCodec(deriveCodec)
-  implicit val mappingAngularLsh: ESC[Mapping.AngularLsh] = ElasticsearchCodec(deriveCodec)
+  implicit val mappingCosineLsh: ESC[Mapping.CosineLsh] = ElasticsearchCodec(deriveCodec)
   implicit val mappingL2Lsh: ESC[Mapping.L2Lsh] = ElasticsearchCodec(deriveCodec)
   implicit val mappingPermutationLsh: ESC[Mapping.PermutationLsh] = ElasticsearchCodec(deriveCodec)
 
@@ -175,7 +178,7 @@ object ElasticsearchCodec { esc =>
           JsonObject(TYPE -> EKNN_SPARSE_BOOL_VECTOR, ELASTIKNN_NAME -> (esc.encode(m) ++ JsonObject(MODEL -> LSH, SIMILARITY -> JACCARD)))
         case m: Mapping.HammingLsh =>
           JsonObject(TYPE -> EKNN_SPARSE_BOOL_VECTOR, ELASTIKNN_NAME -> (esc.encode(m) ++ JsonObject(MODEL -> LSH, SIMILARITY -> HAMMING)))
-        case m: Mapping.AngularLsh =>
+        case m: Mapping.CosineLsh =>
           JsonObject(TYPE -> EKNN_DENSE_FLOAT_VECTOR, ELASTIKNN_NAME -> (esc.encode(m) ++ JsonObject(MODEL -> LSH, SIMILARITY -> ANGULAR)))
         case m: Mapping.L2Lsh =>
           JsonObject(TYPE -> EKNN_DENSE_FLOAT_VECTOR, ELASTIKNN_NAME -> (esc.encode(m) ++ JsonObject(MODEL -> LSH, SIMILARITY -> L2)))
@@ -200,8 +203,8 @@ object ElasticsearchCodec { esc =>
             esc.decode[Mapping.JaccardLsh](c)
           case (EKNN_SPARSE_BOOL_VECTOR, Some(LSH), Some(Similarity.Hamming)) =>
             esc.decode[Mapping.HammingLsh](c)
-          case (EKNN_DENSE_FLOAT_VECTOR, Some(LSH), Some(Similarity.Angular)) =>
-            esc.decode[Mapping.AngularLsh](c)
+          case (EKNN_DENSE_FLOAT_VECTOR, Some(LSH), Some(Similarity.Cosine)) =>
+            esc.decode[Mapping.CosineLsh](c)
           case (EKNN_DENSE_FLOAT_VECTOR, Some(LSH), Some(Similarity.L2)) =>
             esc.decode[Mapping.L2Lsh](c)
           case (EKNN_DENSE_FLOAT_VECTOR, Some(PERMUTATION_LSH), _) => esc.decode[Mapping.PermutationLsh](c)
@@ -222,7 +225,7 @@ object ElasticsearchCodec { esc =>
     implicit val cfg: Configuration = Configuration.default.withDefaults
     ElasticsearchCodec(deriveConfiguredCodec)
   }
-  implicit val queryAngularLsh: ESC[NearestNeighborsQuery.AngularLsh] = {
+  implicit val queryAngularLsh: ESC[NearestNeighborsQuery.CosineLsh] = {
     implicit val cfg: Configuration = Configuration.default.withDefaults
     ElasticsearchCodec(deriveConfiguredCodec)
   }
@@ -243,7 +246,7 @@ object ElasticsearchCodec { esc =>
         case q: NearestNeighborsQuery.SparseIndexed  => JsonObject(MODEL -> SPARSE_INDEXED) ++ (default ++ esc.encode(q))
         case q: NearestNeighborsQuery.JaccardLsh     => JsonObject(MODEL -> LSH) ++ (default ++ esc.encode(q))
         case q: NearestNeighborsQuery.HammingLsh     => JsonObject(MODEL -> LSH) ++ (default ++ esc.encode(q))
-        case q: NearestNeighborsQuery.AngularLsh     => JsonObject(MODEL -> LSH) ++ (default ++ esc.encode(q))
+        case q: NearestNeighborsQuery.CosineLsh      => JsonObject(MODEL -> LSH) ++ (default ++ esc.encode(q))
         case q: NearestNeighborsQuery.L2Lsh          => JsonObject(MODEL -> LSH) ++ (default ++ esc.encode(q))
         case q: NearestNeighborsQuery.PermutationLsh => JsonObject(MODEL -> PERMUTATION_LSH) ++ (default ++ esc.encode(q))
       }
@@ -260,7 +263,7 @@ object ElasticsearchCodec { esc =>
             sim match {
               case Similarity.Jaccard => esc.decode[NearestNeighborsQuery.JaccardLsh](c)
               case Similarity.Hamming => esc.decode[NearestNeighborsQuery.HammingLsh](c)
-              case Similarity.Angular => esc.decode[NearestNeighborsQuery.AngularLsh](c)
+              case Similarity.Cosine  => esc.decode[NearestNeighborsQuery.CosineLsh](c)
               case Similarity.L2      => esc.decode[NearestNeighborsQuery.L2Lsh](c)
               case other              => fail(s"$SIMILARITY [$other] is not compatible with $MODEL [$LSH]")
             }

--- a/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/package.scala
+++ b/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/package.scala
@@ -14,8 +14,8 @@ package object api {
     case object Hamming extends Similarity
     case object L1 extends Similarity
     case object L2 extends Similarity
-    case object Angular extends Similarity
-    val values: Seq[Similarity] = Seq(Jaccard, Hamming, L1, L2, Angular)
+    case object Cosine extends Similarity
+    val values: Seq[Similarity] = Seq(Jaccard, Hamming, L1, L2, Cosine)
   }
 
   sealed trait Vec
@@ -111,7 +111,7 @@ package object api {
     final case class JaccardLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class HammingLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class DenseFloat(dims: Int) extends Mapping
-    final case class AngularLsh(dims: Int, L: Int, k: Int) extends Mapping
+    final case class CosineLsh(dims: Int, L: Int, k: Int) extends Mapping
     final case class L2Lsh(dims: Int, L: Int, k: Int, w: Int) extends Mapping
     final case class PermutationLsh(dims: Int, k: Int, repeating: Boolean) extends Mapping
   }
@@ -148,10 +148,10 @@ package object api {
       override def similarity: Similarity = Similarity.Hamming
     }
 
-    final case class AngularLsh(field: String, candidates: Int, vec: Vec = Vec.Empty()) extends ApproximateQuery {
+    final case class CosineLsh(field: String, candidates: Int, vec: Vec = Vec.Empty()) extends ApproximateQuery {
       override def withVec(v: Vec): NearestNeighborsQuery = copy(vec = v)
       override def withCandidates(candidates: Int): ApproximateQuery = copy(candidates = candidates)
-      override def similarity: Similarity = Similarity.Angular
+      override def similarity: Similarity = Similarity.Cosine
     }
 
     final case class L2Lsh(field: String, candidates: Int, probes: Int = 0, vec: Vec = Vec.Empty()) extends ApproximateQuery {

--- a/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
+++ b/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/Execute.scala
@@ -19,13 +19,15 @@ import zio.stream._
   */
 object Execute extends App {
 
-  final case class Params(experimentKey: String = "",
-                          datasetsPrefix: String = "",
-                          resultsPrefix: String = "",
-                          recompute: Boolean = false,
-                          bucket: String = "",
-                          s3Url: Option[String] = None,
-                          esUrl: String = "http://localhost:9200")
+  final case class Params(
+      experimentKey: String = "",
+      datasetsPrefix: String = "",
+      resultsPrefix: String = "",
+      recompute: Boolean = false,
+      bucket: String = "",
+      s3Url: Option[String] = None,
+      esUrl: String = "http://localhost:9200"
+  )
 
   private val parser = new scopt.OptionParser[Params]("Execute benchmark jobs") {
     override def showUsageOnError: Option[Boolean] = Some(true)
@@ -120,9 +122,9 @@ object Execute extends App {
     } yield {
       // Same method for computing recall as ann-benchmarks.
       def lowerBound(dists: Seq[Float]): Double = query.nnq.similarity match {
-        case Similarity.L2      => dists.map(d => 1 / (1 + d)).min
-        case Similarity.Angular => dists.map(2 - _).min
-        case _                  => Double.MaxValue
+        case Similarity.L2     => dists.map(d => 1 / (1 + d)).min
+        case Similarity.Cosine => dists.map(2 - _).min
+        case _                 => Double.MaxValue
       }
 
       val recalls = results

--- a/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/package.scala
+++ b/elastiknn-benchmarks/src/main/scala/com/klibisz/elastiknn/benchmarks/package.scala
@@ -32,28 +32,30 @@ package object benchmarks {
     def algorithmName: String = {
       import NearestNeighborsQuery._
       nnq match {
-        case _: Exact                                                 => "Exact"
-        case _: SparseIndexed                                         => "Sparse Indexed"
-        case _: HammingLsh | _: JaccardLsh | _: AngularLsh | _: L2Lsh => "LSH"
-        case _: PermutationLsh                                        => "Permutation LSH"
+        case _: Exact                                                => "Exact"
+        case _: SparseIndexed                                        => "Sparse Indexed"
+        case _: HammingLsh | _: JaccardLsh | _: CosineLsh | _: L2Lsh => "LSH"
+        case _: PermutationLsh                                       => "Permutation LSH"
       }
     }
   }
 
   final case class QueryResult(scores: Seq[Float], duration: Long)
 
-  final case class Experiment(dataset: Dataset,
-                              mapping: Mapping,
-                              queries: Seq[Query],
-                              shards: Int = 1,
-                              replicas: Int = 0,
-                              parallelQueries: Int = 1,
-                              esNodes: Int = 1,
-                              esCoresPerNode: Int = 1,
-                              esMemoryGb: Int = 4,
-                              warmupQueries: Int = 200,
-                              minWarmupRounds: Int = 10,
-                              maxWarmupRounds: Int = 10) {
+  final case class Experiment(
+      dataset: Dataset,
+      mapping: Mapping,
+      queries: Seq[Query],
+      shards: Int = 1,
+      replicas: Int = 0,
+      parallelQueries: Int = 1,
+      esNodes: Int = 1,
+      esCoresPerNode: Int = 1,
+      esMemoryGb: Int = 4,
+      warmupQueries: Int = 200,
+      minWarmupRounds: Int = 10,
+      maxWarmupRounds: Int = 10
+  ) {
 
     def uuid: String = DigestUtils.sha256Hex(this.hashCode.toString).toLowerCase
 
@@ -75,24 +77,26 @@ package object benchmarks {
         |)""".stripMargin
   }
 
-  final case class BenchmarkResult(dataset: Dataset,
-                                   similarity: Similarity,
-                                   algorithm: String,
-                                   mapping: Mapping,
-                                   query: NearestNeighborsQuery,
-                                   k: Int,
-                                   shards: Int,
-                                   replicas: Int,
-                                   parallelQueries: Int,
-                                   esNodes: Int,
-                                   esCoresPerNode: Int,
-                                   esMemoryGb: Int,
-                                   warmupQueries: Int,
-                                   minWarmupRounds: Int,
-                                   maxWarmupRounds: Int,
-                                   recall: Float,
-                                   queriesPerSecond: Float,
-                                   durationMillis: Long) {
+  final case class BenchmarkResult(
+      dataset: Dataset,
+      similarity: Similarity,
+      algorithm: String,
+      mapping: Mapping,
+      query: NearestNeighborsQuery,
+      k: Int,
+      shards: Int,
+      replicas: Int,
+      parallelQueries: Int,
+      esNodes: Int,
+      esCoresPerNode: Int,
+      esMemoryGb: Int,
+      warmupQueries: Int,
+      minWarmupRounds: Int,
+      maxWarmupRounds: Int,
+      recall: Float,
+      queriesPerSecond: Float,
+      durationMillis: Long
+  ) {
     lazy val md5sum: String = DigestUtils.md5Hex(codecs.resultCodec(this).noSpaces).toLowerCase
   }
 

--- a/elastiknn-models/src/main/java/com/klibisz/elastiknn/models/CosineLshModel.java
+++ b/elastiknn-models/src/main/java/com/klibisz/elastiknn/models/CosineLshModel.java
@@ -7,21 +7,21 @@ import static com.klibisz.elastiknn.storage.UnsafeSerialization.writeInt;
 
 import java.util.Random;
 
-public class AngularLshModel implements HashingModel.DenseFloat {
+public class CosineLshModel implements HashingModel.DenseFloat {
 
     private final int L;
     private final int k;
     private final float[][] planes;
 
     /**
-     * Locality sensitive hashing model for Angular similarity.
+     * Locality sensitive hashing model for Cosine similarity.
      * Uses the random hyperplanes method described in Mining Massive Datasets chapter 3.
      * @param dims length of the vectors hashed by this model
      * @param L number of hash tables
      * @param k number of hash functions concatenated to form a hash for each table
      * @param rng random number generator used to instantiate model parameters
      */
-    public AngularLshModel(int dims, int L, int k, Random rng) {
+    public CosineLshModel(int dims, int L, int k, Random rng) {
         this.L = L;
         this.k = k;
         this.planes = new float[L * k][dims];

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/mapper/VectorMapper.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/mapper/VectorMapper.scala
@@ -53,7 +53,7 @@ object VectorMapper {
         else
           mapping match {
             case Mapping.DenseFloat(_)     => Try(ExactQuery.index(field, vec))
-            case m: Mapping.AngularLsh     => Try(HashingQuery.index(field, luceneFieldType, vec, Cache(m).hash(vec.values)))
+            case m: Mapping.CosineLsh      => Try(HashingQuery.index(field, luceneFieldType, vec, Cache(m).hash(vec.values)))
             case m: Mapping.L2Lsh          => Try(HashingQuery.index(field, luceneFieldType, vec, Cache(m).hash(vec.values)))
             case m: Mapping.PermutationLsh => Try(HashingQuery.index(field, luceneFieldType, vec, Cache(m).hash(vec.values)))
             case _                         => Failure(incompatible(mapping, vec))

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/models/Cache.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/models/Cache.scala
@@ -14,13 +14,13 @@ object Cache {
         override def load(key: K): V = f(key)
       })
 
-  private val angular = cache((m: Mapping.AngularLsh) => new AngularLshModel(m.dims, m.L, m.k, new Random(0)))
+  private val angular = cache((m: Mapping.CosineLsh) => new CosineLshModel(m.dims, m.L, m.k, new Random(0)))
   private val jaccard = cache((m: Mapping.JaccardLsh) => new JaccardLshModel(m.L, m.k, new Random(0)))
   private val hamming = cache((m: Mapping.HammingLsh) => new HammingLshModel(m.dims, m.L, m.k, new Random(0)))
   private val l2 = cache((m: Mapping.L2Lsh) => new L2LshModel(m.dims, m.L, m.k, m.w, new Random(0)))
   private val permuttation = cache((m: Mapping.PermutationLsh) => new PermutationLshModel(m.k, m.repeating))
 
-  def apply(m: Mapping.AngularLsh): AngularLshModel = angular.get(m)
+  def apply(m: Mapping.CosineLsh): CosineLshModel = angular.get(m)
   def apply(m: Mapping.JaccardLsh): JaccardLshModel = jaccard.get(m)
   def apply(m: Mapping.HammingLsh): HammingLshModel = hamming.get(m)
   def apply(m: Mapping.L2Lsh): L2LshModel = l2.get(m)

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/models/ExactSimilarityFunction.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/models/ExactSimilarityFunction.scala
@@ -28,7 +28,7 @@ object ExactSimilarityFunction {
     override def maxScore: Float = 1f
     override def apply(v1: Vec.DenseFloat, v2: StoredVec.DenseFloat): Double = m.similarity(v1.values, v2.values)
   }
-  object Angular extends ExactSimilarityFunction[Vec.DenseFloat, StoredVec.DenseFloat] {
+  object Cosine extends ExactSimilarityFunction[Vec.DenseFloat, StoredVec.DenseFloat] {
     private val m = new ExactModel.Angular
     override def maxScore: Float = 2f
     override def apply(v1: Vec.DenseFloat, v2: StoredVec.DenseFloat): Double = m.similarity(v1.values, v2.values);

--- a/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/ElastiknnQuery.scala
+++ b/elastiknn-plugin/src/main/scala/com/klibisz/elastiknn/query/ElastiknnQuery.scala
@@ -53,34 +53,34 @@ object ElastiknnQuery {
     (query, mapping) match {
 
       case (
-            Exact(f, Similarity.Jaccard, v: Vec.SparseBool),
-            _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh
+          Exact(f, Similarity.Jaccard, v: Vec.SparseBool),
+          _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh
           ) =>
         new ExactQuery(f, v, ESF.Jaccard)
 
       case (
-            Exact(f, Similarity.Hamming, v: Vec.SparseBool),
-            _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh
+          Exact(f, Similarity.Hamming, v: Vec.SparseBool),
+          _: Mapping.SparseBool | _: Mapping.SparseIndexed | _: Mapping.JaccardLsh | _: Mapping.HammingLsh
           ) =>
         new ExactQuery(f, v, ESF.Hamming)
 
       case (
-            Exact(f, Similarity.L1, v: Vec.DenseFloat),
-            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh
+          Exact(f, Similarity.L1, v: Vec.DenseFloat),
+          _: Mapping.DenseFloat | _: Mapping.CosineLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh
           ) =>
         new ExactQuery(f, v, ESF.L1)
 
       case (
-            Exact(f, Similarity.L2, v: Vec.DenseFloat),
-            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh
+          Exact(f, Similarity.L2, v: Vec.DenseFloat),
+          _: Mapping.DenseFloat | _: Mapping.CosineLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh
           ) =>
         new ExactQuery(f, v, ESF.L2)
 
       case (
-            Exact(f, Similarity.Angular, v: Vec.DenseFloat),
-            _: Mapping.DenseFloat | _: Mapping.AngularLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh
+          Exact(f, Similarity.Cosine, v: Vec.DenseFloat),
+          _: Mapping.DenseFloat | _: Mapping.CosineLsh | _: Mapping.L2Lsh | _: Mapping.PermutationLsh
           ) =>
-        new ExactQuery(f, v, ESF.Angular)
+        new ExactQuery(f, v, ESF.Cosine)
 
       case (SparseIndexed(f, Similarity.Jaccard, sbv: Vec.SparseBool), _: Mapping.SparseIndexed) =>
         new SparseIndexedQuery(f, sbv, SparseIndexedSimilarityFunction.Jaccard)
@@ -94,14 +94,14 @@ object ElastiknnQuery {
       case (HammingLsh(f, candidates, v: Vec.SparseBool), m: Mapping.HammingLsh) =>
         new HashingQuery(f, v, candidates, Cache(m).hash(v.trueIndices, v.totalIndices), ESF.Hamming)
 
-      case (AngularLsh(f, candidates, v: Vec.DenseFloat), m: Mapping.AngularLsh) =>
-        new HashingQuery(f, v, candidates, Cache(m).hash(v.values), ESF.Angular)
+      case (CosineLsh(f, candidates, v: Vec.DenseFloat), m: Mapping.CosineLsh) =>
+        new HashingQuery(f, v, candidates, Cache(m).hash(v.values), ESF.Cosine)
 
       case (L2Lsh(f, candidates, probes, v: Vec.DenseFloat), m: Mapping.L2Lsh) =>
         new HashingQuery(f, v, candidates, Cache(m).hash(v.values, probes), ESF.L2)
 
-      case (PermutationLsh(f, Similarity.Angular, candidates, v: Vec.DenseFloat), m: Mapping.PermutationLsh) =>
-        new HashingQuery(f, v, candidates, Cache(m).hash(v.values), ESF.Angular)
+      case (PermutationLsh(f, Similarity.Cosine, candidates, v: Vec.DenseFloat), m: Mapping.PermutationLsh) =>
+        new HashingQuery(f, v, candidates, Cache(m).hash(v.values), ESF.Cosine)
 
       case (PermutationLsh(f, Similarity.L2, candidates, v: Vec.DenseFloat), m: Mapping.PermutationLsh) =>
         new HashingQuery(f, v, candidates, Cache(m).hash(v.values), ESF.L2)

--- a/elastiknn-testing/src/main/scala/com/klibisz/elastiknn/testing/ExactSimilarityReference.scala
+++ b/elastiknn-testing/src/main/scala/com/klibisz/elastiknn/testing/ExactSimilarityReference.scala
@@ -17,7 +17,7 @@ object ExactSimilarityReference {
     1 / (1 + manhattanDistance(new DenseVector(v1.values), new DenseVector(v2.values)))
   }
 
-  val Angular: (Vec.DenseFloat, Vec.DenseFloat) => Double = (v1: Vec.DenseFloat, v2: Vec.DenseFloat) => {
+  val Cosine: (Vec.DenseFloat, Vec.DenseFloat) => Double = (v1: Vec.DenseFloat, v2: Vec.DenseFloat) => {
     1 + (1 - cosineDistance(new DenseVector(v1.values.map(_.toDouble)), new DenseVector(v2.values.map(_.toDouble))))
   }
 

--- a/elastiknn-testing/src/main/scala/com/klibisz/elastiknn/testing/TestData.scala
+++ b/elastiknn-testing/src/main/scala/com/klibisz/elastiknn/testing/TestData.scala
@@ -57,7 +57,8 @@ object TestData {
   }
 
   def genDenseFloat(dims: Int, numCorpus: Int, numQueries: Int, numNeighbors: Int, unit: Boolean = false)(
-      implicit rng: Random): TestData = {
+      implicit rng: Random
+  ): TestData = {
     val corpus = Vec.DenseFloat.randoms(dims, numCorpus)
     val queries = Vec.DenseFloat.randoms(dims, numQueries).map { qv =>
       Query(
@@ -65,7 +66,7 @@ object TestData {
         Seq(
           Result(Similarity.L1, corpus.map(cv => ExactSimilarityFunction.L1(cv, qv)).sorted.reverse.take(numNeighbors)),
           Result(Similarity.L2, corpus.map(cv => ExactSimilarityFunction.L2(cv, qv)).sorted.reverse.take(numNeighbors)),
-          Result(Similarity.Angular, corpus.map(cv => ExactSimilarityFunction.Angular(cv, qv)).sorted.reverse.take(numNeighbors))
+          Result(Similarity.Cosine, corpus.map(cv => ExactSimilarityFunction.Cosine(cv, qv)).sorted.reverse.take(numNeighbors))
         )
       )
     }
@@ -85,7 +86,6 @@ object Generate {
     val dims = 1024
     write(genSparseBool(dims, 5000, 50, 100), "testdata-sparsebool.json.gz")
     write(genDenseFloat(dims, 5000, 50, 100), "testdata-densefloat.json.gz")
-    write(genDenseFloat(dims, 5000, 50, 100, unit = true), "testdata-densefloat-unit.json.gz")
   }
 
 }

--- a/elastiknn-testing/src/main/scala/com/klibisz/elastiknn/testing/TestData.scala
+++ b/elastiknn-testing/src/main/scala/com/klibisz/elastiknn/testing/TestData.scala
@@ -86,6 +86,7 @@ object Generate {
     val dims = 1024
     write(genSparseBool(dims, 5000, 50, 100), "testdata-sparsebool.json.gz")
     write(genDenseFloat(dims, 5000, 50, 100), "testdata-densefloat.json.gz")
+    write(genDenseFloat(dims, 5000, 50, 100, unit = true), "testdata-densefloat-unit.json.gz")
   }
 
 }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/api/ElasticsearchCodecSuite.scala
@@ -1,7 +1,7 @@
 package com.klibisz.elastiknn.api
 
 import io.circe
-import io.circe.{DecodingFailure, Json}
+import io.circe._
 import org.scalatest.Assertion
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -106,6 +106,19 @@ class ElasticsearchCodecSuite extends AnyFunSuite with Matchers {
 
     """
       |{
+      | "type": "elastiknn_dense_float_vector",
+      | "elastiknn": {
+      |  "dims": 100,
+      |  "model": "lsh",
+      |  "similarity": "cosine",
+      |  "L": 99,
+      |  "k": 1
+      | }
+      |}
+      |""".stripMargin shouldDecodeTo [Mapping] Mapping.CosineLsh(100, 99, 1)
+
+    """
+      |{
       | "type": "elastiknn_sparse_bool_vector",
       | "elastiknn": {
       |  "dims": 100,
@@ -204,4 +217,42 @@ class ElasticsearchCodecSuite extends AnyFunSuite with Matchers {
       |}
       |""".stripMargin shouldDecodeTo [NearestNeighborsQuery] JaccardLsh("vec", 100, Vec.SparseBool(Array(1, 2, 3), 99))
   }
+
+  // Issue 277: "Angular" was renamed to "Cosine", but we still want backwards compatibility for "Angular" in the codec.
+  test("backwards-compatibility for Angular similarity") {
+
+    ElasticsearchCodec.decodeJson[Similarity](Json.fromString("angular")) shouldBe Right(Similarity.Cosine)
+
+    ElasticsearchCodec.encode(Similarity.Cosine: Similarity) shouldBe Json.fromString("cosine")
+
+    """
+      |{
+      | "type": "elastiknn_dense_float_vector",
+      | "elastiknn": {
+      |  "dims": 100,
+      |  "model": "lsh",
+      |  "similarity": "angular",
+      |  "L": 99,
+      |  "k": 1
+      | }
+      |}
+      |""".stripMargin shouldDecodeTo [Mapping] Mapping.CosineLsh(100, 99, 1)
+
+    """
+      |{
+      | "field": "vec",
+      | "model": "exact",
+      | "similarity": "angular",
+      | "vec": {
+      |   "values": [1,2,3]
+      | }
+      |}
+      |""".stripMargin shouldDecodeTo [NearestNeighborsQuery] NearestNeighborsQuery.Exact(
+      "vec",
+      Similarity.Cosine,
+      Vec.DenseFloat(1f, 2f, 3f)
+    )
+
+  }
+
 }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/CosineLshModelSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/CosineLshModelSuite.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random
 
-class AngularLshModelSuite extends AnyFunSuite with Matchers with LuceneSupport {
+class CosineLshModelSuite extends AnyFunSuite with Matchers with LuceneSupport {
 
   test("model is invariant to vector magnitude") {
     implicit val rng: Random = new Random(0)
@@ -17,7 +17,7 @@ class AngularLshModelSuite extends AnyFunSuite with Matchers with LuceneSupport 
       k <- 1 to 5
       isUnit <- Seq(true, false)
     } {
-      val mlsh = new AngularLshModel(dims, l, k, new java.util.Random(0))
+      val mlsh = new CosineLshModel(dims, l, k, new java.util.Random(0))
       val vec = Vec.DenseFloat.random(dims, unit = isUnit)
       val scaled = (1 to 10).map(m => vec.copy(vec.values.map(_ * m)))
       val hashed = scaled.map(v => mlsh.hash(v.values).toList)

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/ExactSimilarityFunctionSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/ExactSimilarityFunctionSuite.scala
@@ -73,20 +73,20 @@ class ExactSimilarityFunctionSuite extends AnyFunSpec with Matchers with LazyLog
         val len = rng.nextInt(4096) + 10
         val v1 = Vec.DenseFloat.random(len)
         val v2 = Vec.DenseFloat.random(len)
-        ExactSimilarityFunction.Angular(v1, v2) shouldBe (ExactSimilarityReference.Angular(v1, v2) +- tol)
+        ExactSimilarityFunction.Cosine(v1, v2) shouldBe (ExactSimilarityReference.Cosine(v1, v2) +- tol)
       }
     }
 
     it("handles identity") {
       val v1 = Vec.DenseFloat.random(199)
-      ExactSimilarityFunction.Angular(v1, v1) shouldBe (2d +- tol)
+      ExactSimilarityFunction.Cosine(v1, v1) shouldBe (2d +- tol)
     }
 
     it("handles all zeros") {
       val v1 = Vec.DenseFloat.random(199)
       val v2 = Vec.DenseFloat(v1.values.map(_ * 0))
-      ExactSimilarityFunction.Angular(v1, v2) shouldBe >=(0d)
-      ExactSimilarityFunction.Angular(v2, v2) shouldBe 2d
+      ExactSimilarityFunction.Cosine(v1, v2) shouldBe >=(0d)
+      ExactSimilarityFunction.Cosine(v2, v2) shouldBe 2d
     }
 
   }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/PermutationLshModelSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/models/PermutationLshModelSuite.scala
@@ -126,7 +126,7 @@ class PermutationLshModelSuite extends AnyFunSuite with Matchers with LuceneSupp
       } {
         case (r, s) =>
           queryVecs.map { v =>
-            val q = new HashingQuery("vec", v, 200, lsh.hash(v.values), ExactSimilarityFunction.Angular)
+            val q = new HashingQuery("vec", v, 200, lsh.hash(v.values), ExactSimilarityFunction.Cosine)
             s.search(q.toLuceneQuery(r), 100).scoreDocs.map(sd => (sd.doc, sd.score)).toVector
           }
       }

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/DocsWithMissingVectorsSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/DocsWithMissingVectorsSuite.scala
@@ -22,7 +22,7 @@ class DocsWithMissingVectorsSuite extends AsyncFunSuite with Matchers with Inspe
     implicit val rng = new Random(0)
     val index = "issue-181"
     val (vecField, idField, dims, numDocs) = ("vec", "id", 128, 20000)
-    val vecMapping: Mapping = Mapping.AngularLsh(dims, 99, 1)
+    val vecMapping: Mapping = Mapping.CosineLsh(dims, 99, 1)
     val mappingJsonString =
       s"""
          |{
@@ -53,11 +53,11 @@ class DocsWithMissingVectorsSuite extends AsyncFunSuite with Matchers with Inspe
       _ = countWithIdField.result.count shouldBe numDocs
       _ = countWithVecField.result.count shouldBe numDocs / 2
 
-      nbrsExact <- eknn.nearestNeighbors(index, NearestNeighborsQuery.Exact(vecField, Similarity.Angular, v0), 10, idField)
+      nbrsExact <- eknn.nearestNeighbors(index, NearestNeighborsQuery.Exact(vecField, Similarity.Cosine, v0), 10, idField)
       _ = nbrsExact.result.hits.hits.length shouldBe 10
       _ = nbrsExact.result.hits.hits.head.score shouldBe 2f
 
-      nbrsApprox <- eknn.nearestNeighbors(index, NearestNeighborsQuery.AngularLsh(vecField, 13, v0), 10, idField)
+      nbrsApprox <- eknn.nearestNeighbors(index, NearestNeighborsQuery.CosineLsh(vecField, 13, v0), 10, idField)
       _ = nbrsApprox.result.hits.hits.length shouldBe 10
       _ = nbrsApprox.result.hits.hits.head.score shouldBe 2f
     } yield Assertions.succeed

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/DocsWithMultipleVectorsSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/DocsWithMultipleVectorsSuite.scala
@@ -29,10 +29,10 @@ class DocsWithMultipleVectorsSuite extends AsyncFunSuite with Matchers with Insp
     // Some of them are intentionally duplicated.
     val fields: Seq[(String, Mapping, () => String, NearestNeighborsQuery)] = Seq(
       ("d1", Mapping.DenseFloat(dims), genDF, NearestNeighborsQuery.Exact("d1", Similarity.L2)),
-      ("d2", Mapping.AngularLsh(dims, 10, 1), genDF, NearestNeighborsQuery.AngularLsh("d2", n)),
-      ("d3", Mapping.AngularLsh(dims, 10, 1), genDF, NearestNeighborsQuery.AngularLsh("d3", n)),
+      ("d2", Mapping.CosineLsh(dims, 10, 1), genDF, NearestNeighborsQuery.CosineLsh("d2", n)),
+      ("d3", Mapping.CosineLsh(dims, 10, 1), genDF, NearestNeighborsQuery.CosineLsh("d3", n)),
       ("d4", Mapping.L2Lsh(dims, 21, 2, 3), genDF, NearestNeighborsQuery.L2Lsh("d4", n)),
-      ("d5", Mapping.PermutationLsh(dims, 6, false), genDF, NearestNeighborsQuery.PermutationLsh("d5", Similarity.Angular, n)),
+      ("d5", Mapping.PermutationLsh(dims, 6, false), genDF, NearestNeighborsQuery.PermutationLsh("d5", Similarity.Cosine, n)),
       ("b1", Mapping.SparseBool(dims), genSB, NearestNeighborsQuery.Exact("b1", Similarity.Jaccard)),
       ("b2", Mapping.SparseIndexed(dims), genSB, NearestNeighborsQuery.SparseIndexed("b2", Similarity.Jaccard)),
       ("b3", Mapping.JaccardLsh(dims, 10, 2), genSB, NearestNeighborsQuery.JaccardLsh("b3", n)),

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/FunctionScoreQuerySuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/FunctionScoreQuerySuite.scala
@@ -31,13 +31,13 @@ class FunctionScoreQuerySuite extends AsyncFunSuite with Matchers with Inspector
   val mappingsAndQueries = Seq(
     Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
       NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-      NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+      NearestNeighborsQuery.Exact("vec", Similarity.Cosine, queryVec),
       NearestNeighborsQuery.L2Lsh("vec", candidates, vec = queryVec)
     ),
-    Mapping.AngularLsh(dims, 40, 1) -> Seq(
+    Mapping.CosineLsh(dims, 40, 1) -> Seq(
       NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-      NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
-      NearestNeighborsQuery.AngularLsh("vec", candidates, queryVec)
+      NearestNeighborsQuery.Exact("vec", Similarity.Cosine, queryVec),
+      NearestNeighborsQuery.CosineLsh("vec", candidates, queryVec)
     )
   )
 

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/JavaClientSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/JavaClientSuite.scala
@@ -61,15 +61,15 @@ class JavaClientSuite extends AsyncFunSuite with Matchers with ElasticAsyncClien
       new ElastiknnNearestNeighborsQuery.Exact(new api4j.Vector.DenseFloat(dfv.values), api4j.Similarity.L2) ->
         NearestNeighborsQuery.Exact("vec", Similarity.L2, dfv),
       new ElastiknnNearestNeighborsQuery.Exact(new api4j.Vector.DenseFloat(dfv.values), api4j.Similarity.ANGULAR) ->
-        NearestNeighborsQuery.Exact("vec", Similarity.Angular, dfv),
+        NearestNeighborsQuery.Exact("vec", Similarity.Cosine, dfv),
       new ElastiknnNearestNeighborsQuery.Exact(new api4j.Vector.SparseBool(sbv.trueIndices, sbv.totalIndices), api4j.Similarity.JACCARD) ->
         NearestNeighborsQuery.Exact("vec", Similarity.Jaccard, sbv),
       new ElastiknnNearestNeighborsQuery.L2Lsh(new api4j.Vector.DenseFloat(dfv.values), 22, 3) ->
         NearestNeighborsQuery.L2Lsh("vec", 22, 3, dfv),
       new ElastiknnNearestNeighborsQuery.AngularLsh(new api4j.Vector.DenseFloat(dfv.values), 22) ->
-        NearestNeighborsQuery.AngularLsh("vec", 22, dfv),
+        NearestNeighborsQuery.CosineLsh("vec", 22, dfv),
       new ElastiknnNearestNeighborsQuery.PermutationLsh(new api4j.Vector.DenseFloat(dfv.values), api4j.Similarity.ANGULAR, 22) ->
-        NearestNeighborsQuery.PermutationLsh("vec", Similarity.Angular, 22, dfv),
+        NearestNeighborsQuery.PermutationLsh("vec", Similarity.Cosine, 22, dfv),
       new ElastiknnNearestNeighborsQuery.PermutationLsh(new api4j.Vector.DenseFloat(dfv.values), api4j.Similarity.L2, 22) ->
         NearestNeighborsQuery.PermutationLsh("vec", Similarity.L2, 22, dfv)
     )

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/QueryRescorerSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/QueryRescorerSuite.scala
@@ -32,13 +32,13 @@ class QueryRescorerSuite extends AsyncFunSuite with Matchers with Inspectors wit
   val mappingsAndQueries = Seq(
     Mapping.L2Lsh(dims, 40, 1, 2) -> Seq(
       NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-      NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
+      NearestNeighborsQuery.Exact("vec", Similarity.Cosine, queryVec),
       NearestNeighborsQuery.L2Lsh("vec", candidates, vec = queryVec)
     ),
-    Mapping.AngularLsh(dims, 40, 1) -> Seq(
+    Mapping.CosineLsh(dims, 40, 1) -> Seq(
       NearestNeighborsQuery.Exact("vec", Similarity.L2, queryVec),
-      NearestNeighborsQuery.Exact("vec", Similarity.Angular, queryVec),
-      NearestNeighborsQuery.AngularLsh("vec", candidates, queryVec)
+      NearestNeighborsQuery.Exact("vec", Similarity.Cosine, queryVec),
+      NearestNeighborsQuery.CosineLsh("vec", candidates, queryVec)
     )
   )
 

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -122,22 +122,22 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
         NearestNeighborsQuery.CosineLsh(vecField, 400) -> 0.51,
         NearestNeighborsQuery.CosineLsh(vecField, 800) -> 0.72
       )
-    )
+    ),
     // L2 Lsh
-      Test (
-        Mapping.L2Lsh(dims, 600, 1, 4),
-        Seq(
-          NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-          NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-          NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-          NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.12,
-          NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.22,
-          NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.40,
-          // Adding probes should improve recall, but since k = 1, probing > 2 times should have no effect.
-          NearestNeighborsQuery.L2Lsh(vecField, 800, 1) -> 0.43,
-          NearestNeighborsQuery.L2Lsh(vecField, 800, 2) -> 0.49,
-          NearestNeighborsQuery.L2Lsh(vecField, 800, 10) -> 0.49
-        )
+    Test(
+      Mapping.L2Lsh(dims, 600, 1, 4),
+      Seq(
+        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Cosine) -> 1d,
+        NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.12,
+        NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.22,
+        NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.40,
+        // Adding probes should improve recall, but since k = 1, probing > 2 times should have no effect.
+        NearestNeighborsQuery.L2Lsh(vecField, 800, 1) -> 0.43,
+        NearestNeighborsQuery.L2Lsh(vecField, 800, 2) -> 0.49,
+        NearestNeighborsQuery.L2Lsh(vecField, 800, 10) -> 0.49
+      )
     ),
     // Permutation Lsh
     Test(
@@ -145,9 +145,9 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
       Seq(
         NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.14,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.21,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Cosine) -> 1d,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Cosine, 200) -> 0.14,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Cosine, 400) -> 0.21,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.12,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.20
       ),
@@ -159,9 +159,9 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
       Seq(
         NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.31,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.51,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Cosine) -> 1d,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Cosine, 200) -> 0.31,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Cosine, 400) -> 0.51,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.3,
         NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.43
       ),

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -57,53 +57,53 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
         NearestNeighborsQuery.Exact(vecField, Similarity.Cosine) -> 1d
       )
     ),
-//    // SparseIndexed
-//    Test(
-//      Mapping.SparseIndexed(dims),
-//      Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
-//        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Jaccard) -> 1d,
-//        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Hamming) -> 1d
-//      )
-//    ),
-//    // Jaccard LSH
-//    Test(
-//      Mapping.JaccardLsh(dims, 200, 1),
-//      Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
-//        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.69,
-//        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.87
-//      )
-//    ),
-//    Test(
-//      Mapping.JaccardLsh(dims, 300, 2),
-//      Seq(
-//        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.62,
-//        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.81
-//      )
-//    ),
-//    // Hamming LSH
-//    Test(
-//      Mapping.HammingLsh(dims, dims * 1 / 2, 1),
-//      Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
-//        NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.72,
-//        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.92
-//      )
-//    ),
-//    Test(
-//      // Increasing k increases recall up to a point.
-//      Mapping.HammingLsh(dims, dims * 2 / 5, 2),
-//      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.86)
-//    ),
-//    Test(
-//      // But increasing it too far decreases recall.
-//      Mapping.HammingLsh(dims, dims * 2 / 5, 4),
-//      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.65)
-//    ),
+    // SparseIndexed
+    Test(
+      Mapping.SparseIndexed(dims),
+      Seq(
+        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Jaccard) -> 1d,
+        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Hamming) -> 1d
+      )
+    ),
+    // Jaccard LSH
+    Test(
+      Mapping.JaccardLsh(dims, 200, 1),
+      Seq(
+        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.69,
+        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.87
+      )
+    ),
+    Test(
+      Mapping.JaccardLsh(dims, 300, 2),
+      Seq(
+        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.62,
+        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.81
+      )
+    ),
+    // Hamming LSH
+    Test(
+      Mapping.HammingLsh(dims, dims * 1 / 2, 1),
+      Seq(
+        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+        NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.72,
+        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.92
+      )
+    ),
+    Test(
+      // Increasing k increases recall up to a point.
+      Mapping.HammingLsh(dims, dims * 2 / 5, 2),
+      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.86)
+    ),
+    Test(
+      // But increasing it too far decreases recall.
+      Mapping.HammingLsh(dims, dims * 2 / 5, 4),
+      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.65)
+    ),
     // Angular Lsh
     Test(
       Mapping.CosineLsh(dims, 400, 1),
@@ -123,51 +123,51 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
         NearestNeighborsQuery.CosineLsh(vecField, 800) -> 0.72
       )
     )
-//    // L2 Lsh
-//    Test(
-//      Mapping.L2Lsh(dims, 600, 1, 4),
-//      Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-//        NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.12,
-//        NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.22,
-//        NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.40,
-//        // Adding probes should improve recall, but since k = 1, probing > 2 times should have no effect.
-//        NearestNeighborsQuery.L2Lsh(vecField, 800, 1) -> 0.43,
-//        NearestNeighborsQuery.L2Lsh(vecField, 800, 2) -> 0.49,
-//        NearestNeighborsQuery.L2Lsh(vecField, 800, 10) -> 0.49
-//      )
-//    ),
-//    // Permutation Lsh
-//    Test(
-//      Mapping.PermutationLsh(dims, 128, true),
-//      Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.14,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.21,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.12,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.20
-//      ),
-//      // TODO: This one seems to be more sensitive for some unknown reason.
-//      recallTolerance = 5e-2
-//    ),
-//    Test(
-//      Mapping.PermutationLsh(dims, 128, false),
-//      Seq(
-//        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-//        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.31,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.51,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.3,
-//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.43
-//      ),
-//      // TODO: This one seems to be more sensitive for some unknown reason.
-//      recallTolerance = 5e-2
-//    )
+    // L2 Lsh
+      Test (
+        Mapping.L2Lsh(dims, 600, 1, 4),
+        Seq(
+          NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+          NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+          NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
+          NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.12,
+          NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.22,
+          NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.40,
+          // Adding probes should improve recall, but since k = 1, probing > 2 times should have no effect.
+          NearestNeighborsQuery.L2Lsh(vecField, 800, 1) -> 0.43,
+          NearestNeighborsQuery.L2Lsh(vecField, 800, 2) -> 0.49,
+          NearestNeighborsQuery.L2Lsh(vecField, 800, 10) -> 0.49
+        )
+    ),
+    // Permutation Lsh
+    Test(
+      Mapping.PermutationLsh(dims, 128, true),
+      Seq(
+        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.14,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.21,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.12,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.20
+      ),
+      // TODO: This one seems to be more sensitive for some unknown reason.
+      recallTolerance = 5e-2
+    ),
+    Test(
+      Mapping.PermutationLsh(dims, 128, false),
+      Seq(
+        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.31,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.51,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.3,
+        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.43
+      ),
+      // TODO: This one seems to be more sensitive for some unknown reason.
+      recallTolerance = 5e-2
+    )
   )
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -222,7 +222,7 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
       case Similarity.Hamming => sparseBoolTestData
       case Similarity.L1      => denseFloatTestData
       case Similarity.L2      => denseFloatTestData
-      case Similarity.Cosine  => denseFloatTestData
+      case Similarity.Cosine  => denseFloatUnitTestData
     }
   } {
     val uuid = UUID.randomUUID().toString

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -39,6 +39,7 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
   private val segmentsPerShard: Int = 1
   private val sparseBoolTestData = TestData.read("testdata-sparsebool.json.gz")
   private val denseFloatTestData = TestData.read("testdata-densefloat.json.gz")
+  private val denseFloatUnitTestData = TestData.read("testdata-densefloat-unit.json.gz")
 
   private val tests = Seq(
     // Exact
@@ -119,7 +120,7 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
       Mapping.CosineLsh(dims, 400, 2),
       Seq(
         NearestNeighborsQuery.CosineLsh(vecField, 200) -> 0.34,
-        NearestNeighborsQuery.CosineLsh(vecField, 400) -> 0.51,
+        NearestNeighborsQuery.CosineLsh(vecField, 400) -> 0.50,
         NearestNeighborsQuery.CosineLsh(vecField, 800) -> 0.72
       )
     ),

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -39,7 +39,6 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
   private val segmentsPerShard: Int = 1
   private val sparseBoolTestData = TestData.read("testdata-sparsebool.json.gz")
   private val denseFloatTestData = TestData.read("testdata-densefloat.json.gz")
-  private val denseFloatUnitTestData = TestData.read("testdata-densefloat-unit.json.gz")
 
   private val tests = Seq(
     // Exact
@@ -55,120 +54,120 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
       Seq(
         NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d
+        NearestNeighborsQuery.Exact(vecField, Similarity.Cosine) -> 1d
       )
     ),
-    // SparseIndexed
-    Test(
-      Mapping.SparseIndexed(dims),
-      Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
-        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Jaccard) -> 1d,
-        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Hamming) -> 1d
-      )
-    ),
-    // Jaccard LSH
-    Test(
-      Mapping.JaccardLsh(dims, 200, 1),
-      Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
-        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.69,
-        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.87
-      )
-    ),
-    Test(
-      Mapping.JaccardLsh(dims, 300, 2),
-      Seq(
-        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.62,
-        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.81
-      )
-    ),
-    // Hamming LSH
-    Test(
-      Mapping.HammingLsh(dims, dims * 1 / 2, 1),
-      Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
-        NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.72,
-        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.92
-      )
-    ),
-    Test(
-      // Increasing k increases recall up to a point.
-      Mapping.HammingLsh(dims, dims * 2 / 5, 2),
-      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.86)
-    ),
-    Test(
-      // But increasing it too far decreases recall.
-      Mapping.HammingLsh(dims, dims * 2 / 5, 4),
-      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.65)
-    ),
+//    // SparseIndexed
+//    Test(
+//      Mapping.SparseIndexed(dims),
+//      Seq(
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+//        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Jaccard) -> 1d,
+//        NearestNeighborsQuery.SparseIndexed(vecField, Similarity.Hamming) -> 1d
+//      )
+//    ),
+//    // Jaccard LSH
+//    Test(
+//      Mapping.JaccardLsh(dims, 200, 1),
+//      Seq(
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+//        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.69,
+//        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.87
+//      )
+//    ),
+//    Test(
+//      Mapping.JaccardLsh(dims, 300, 2),
+//      Seq(
+//        NearestNeighborsQuery.JaccardLsh(vecField, 400) -> 0.62,
+//        NearestNeighborsQuery.JaccardLsh(vecField, 800) -> 0.81
+//      )
+//    ),
+//    // Hamming LSH
+//    Test(
+//      Mapping.HammingLsh(dims, dims * 1 / 2, 1),
+//      Seq(
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Jaccard) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Hamming) -> 1d,
+//        NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.72,
+//        NearestNeighborsQuery.HammingLsh(vecField, 400) -> 0.92
+//      )
+//    ),
+//    Test(
+//      // Increasing k increases recall up to a point.
+//      Mapping.HammingLsh(dims, dims * 2 / 5, 2),
+//      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.86)
+//    ),
+//    Test(
+//      // But increasing it too far decreases recall.
+//      Mapping.HammingLsh(dims, dims * 2 / 5, 4),
+//      Seq(NearestNeighborsQuery.HammingLsh(vecField, 200) -> 0.65)
+//    ),
     // Angular Lsh
     Test(
-      Mapping.AngularLsh(dims, 400, 1),
+      Mapping.CosineLsh(dims, 400, 1),
       Seq(
         NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
         NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.AngularLsh(vecField, 400) -> 0.46,
-        NearestNeighborsQuery.AngularLsh(vecField, 800) -> 0.67
+        NearestNeighborsQuery.Exact(vecField, Similarity.Cosine) -> 1d,
+        NearestNeighborsQuery.CosineLsh(vecField, 400) -> 0.46,
+        NearestNeighborsQuery.CosineLsh(vecField, 800) -> 0.67
       )
     ),
     Test(
-      Mapping.AngularLsh(dims, 400, 2),
+      Mapping.CosineLsh(dims, 400, 2),
       Seq(
-        NearestNeighborsQuery.AngularLsh(vecField, 200) -> 0.34,
-        NearestNeighborsQuery.AngularLsh(vecField, 400) -> 0.50,
-        NearestNeighborsQuery.AngularLsh(vecField, 800) -> 0.72
+        NearestNeighborsQuery.CosineLsh(vecField, 200) -> 0.34,
+        NearestNeighborsQuery.CosineLsh(vecField, 400) -> 0.51,
+        NearestNeighborsQuery.CosineLsh(vecField, 800) -> 0.72
       )
-    ),
-    // L2 Lsh
-    Test(
-      Mapping.L2Lsh(dims, 600, 1, 4),
-      Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.12,
-        NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.22,
-        NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.40,
-        // Adding probes should improve recall, but since k = 1, probing > 2 times should have no effect.
-        NearestNeighborsQuery.L2Lsh(vecField, 800, 1) -> 0.43,
-        NearestNeighborsQuery.L2Lsh(vecField, 800, 2) -> 0.49,
-        NearestNeighborsQuery.L2Lsh(vecField, 800, 10) -> 0.49
-      )
-    ),
-    // Permutation Lsh
-    Test(
-      Mapping.PermutationLsh(dims, 128, true),
-      Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.14,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.21,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.12,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.20
-      ),
-      // TODO: This one seems to be more sensitive for some unknown reason.
-      recallTolerance = 5e-2
-    ),
-    Test(
-      Mapping.PermutationLsh(dims, 128, false),
-      Seq(
-        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
-        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.31,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.51,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.3,
-        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.43
-      ),
-      // TODO: This one seems to be more sensitive for some unknown reason.
-      recallTolerance = 5e-2
     )
+//    // L2 Lsh
+//    Test(
+//      Mapping.L2Lsh(dims, 600, 1, 4),
+//      Seq(
+//        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
+//        NearestNeighborsQuery.L2Lsh(vecField, 200) -> 0.12,
+//        NearestNeighborsQuery.L2Lsh(vecField, 400) -> 0.22,
+//        NearestNeighborsQuery.L2Lsh(vecField, 800) -> 0.40,
+//        // Adding probes should improve recall, but since k = 1, probing > 2 times should have no effect.
+//        NearestNeighborsQuery.L2Lsh(vecField, 800, 1) -> 0.43,
+//        NearestNeighborsQuery.L2Lsh(vecField, 800, 2) -> 0.49,
+//        NearestNeighborsQuery.L2Lsh(vecField, 800, 10) -> 0.49
+//      )
+//    ),
+//    // Permutation Lsh
+//    Test(
+//      Mapping.PermutationLsh(dims, 128, true),
+//      Seq(
+//        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.14,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.21,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.12,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.20
+//      ),
+//      // TODO: This one seems to be more sensitive for some unknown reason.
+//      recallTolerance = 5e-2
+//    ),
+//    Test(
+//      Mapping.PermutationLsh(dims, 128, false),
+//      Seq(
+//        NearestNeighborsQuery.Exact(vecField, Similarity.L1) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.L2) -> 1d,
+//        NearestNeighborsQuery.Exact(vecField, Similarity.Angular) -> 1d,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 200) -> 0.31,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.Angular, 400) -> 0.51,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 200) -> 0.3,
+//        NearestNeighborsQuery.PermutationLsh(vecField, Similarity.L2, 400) -> 0.43
+//      ),
+//      // TODO: This one seems to be more sensitive for some unknown reason.
+//      recallTolerance = 5e-2
+//    )
   )
 
   private def index(corpusIndex: String, queriesIndex: String, mapping: Mapping, testData: TestData): Future[Unit] =
@@ -222,7 +221,7 @@ class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient {
       case Similarity.Hamming => sparseBoolTestData
       case Similarity.L1      => denseFloatTestData
       case Similarity.L2      => denseFloatTestData
-      case Similarity.Angular => denseFloatUnitTestData
+      case Similarity.Cosine  => denseFloatTestData
     }
   } {
     val uuid = UUID.randomUUID().toString


### PR DESCRIPTION
This PR renames all instanes of "Angular" to "Cosine" in the plugin and scala client. 
See discussion on #277 for justification.
The serialization layer maintains backwards compatibility, so that any reference of Angular is mapped to Cosine.
There will be follow-ups to update the Python and Java clients as well.