### PR TITLE
Tests: Set test index replication to 1

### DIFF
--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/ApproximateQueryTotalHitsSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/ApproximateQueryTotalHitsSuite.scala
@@ -34,7 +34,7 @@ class ApproximateQueryTotalHitsSuite extends AsyncFunSuite with Matchers with El
 
     for {
       _ <- deleteIfExists(index)
-      _ <- eknn.createIndex(index, 3, 2)
+      _ <- eknn.createIndex(index, 3, 1)
       _ <- eknn.putMapping(index, vecField, idField, mapping)
       _ <- eknn.index(index, vecField, corpus, idField, ids)
       _ <- eknn.execute(refreshIndex(index))

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MixedIndexSearchDeleteSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/MixedIndexSearchDeleteSuite.scala
@@ -63,7 +63,7 @@ class MixedIndexSearchDeleteSuite extends AsyncFunSuite with Matchers with Inspe
 
     for {
       _ <- deleteIfExists(index)
-      _ <- eknn.createIndex(index, 3, 2)
+      _ <- eknn.createIndex(index, 3, 1)
       _ <- eknn.putMapping(index, vecField, idField, mapping)
       _ <- eknn.index(index, vecField, corpus, idField, ids)
       _ <- eknn.execute(refreshIndex(index))


### PR DESCRIPTION
A couple of the tests were creating indexes w/ > 1 replica.
Since there is only one data node, this made cluster status "yellow".
This only came up in #317, possibly due to changed scalatest ordering.
Re: #316 