### PR TITLE
Build: only publish snapshots if actor is alexklibisz and tests have passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
   # there's no way to make a job conditional on another job.
   publish-snapshots:
     runs-on: ubuntu-20.04
-    if: ${{ github.actor == 'aaaalexklibisz' }}
+    if: ${{ github.actor == 'alexklibisz' }}
+    needs: [show-github-context, test-jvm, test-python]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,6 @@ jobs:
   # there's no way to make a job conditional on another job.
   publish-snapshots:
     if: github.actor == "alexklibisz"
-    needs: [show-github-context, test-jvm, test-python, build-jekyll-site]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # there's no way to make a job conditional on another job.
   publish-snapshots:
     runs-on: ubuntu-20.04
-    if: $${{ github.actor == 'alexklibisz' }}
+    if: $${{ github.actor == 'aaaalexklibisz' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
   # Ideally the snapshot release would run only if the tests pass, but right now
   # there's no way to make a job conditional on another job.
   publish-snapshots:
+    if: github.actor == "alexklibisz"
+    needs: [show-github-context, test-jvm, test-python, build-jekyll-site]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -113,6 +115,7 @@ jobs:
           python3 -m pip install setuptools
       - name: Publish to PyPi
         run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
+        if: github.event_name == 'pull_request'
       - name: Publish JVM Libraries from PR
         if: github.event_name == 'pull_request'
         run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # there's no way to make a job conditional on another job.
   publish-snapshots:
     runs-on: ubuntu-20.04
-    if: $${{ github.actor == 'aaaalexklibisz' }}
+    if: ${{ github.actor == 'aaaalexklibisz' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   show-github-context:
     runs-on: ubuntu-20.04
-    if: github.actor == "alexklibisz"
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:
@@ -88,7 +87,6 @@ jobs:
   # Ideally the snapshot release would run only if the tests pass, but right now
   # there's no way to make a job conditional on another job.
   publish-snapshots:
-    if: github.actor == "alexklibisz"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   show-github-context:
     runs-on: ubuntu-20.04
+    if: github.actor == "alexklibisz"
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
   # there's no way to make a job conditional on another job.
   publish-snapshots:
     runs-on: ubuntu-20.04
+    if: $${{ github.actor == 'alexklibisz' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/elastiknn-testing/docker-compose.yml
+++ b/elastiknn-testing/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - bootstrap.memory_lock=true
       - http.cors.enabled=true
       - http.cors.allow-origin=*
+      - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms700m -Xmx700m
     ports:
       - "9200:9200"


### PR DESCRIPTION
This will entirely skip the "publish-snapshots" job when another user makes a PR. This currently fails bc Github (correctly) prevents sharing credentials across accounts.