### PR TITLE
#387: Fix ann-benchmarks tests

### DIFF
--- a/client-python/elastiknn/client.py
+++ b/client-python/elastiknn/client.py
@@ -57,8 +57,7 @@ class ElastiknnClient(object):
                 }
             }
         }
-        return self.es.transport.perform_request("PUT", f"/{index}/_mapping", body=body,
-                                                 headers={"Content-Type": "application/json"})
+        return self.es.transport.perform_request("PUT", f"/{index}/_mapping", body=body)
 
     def index(self, index: str, vec_field: str, vecs: Iterable[Vec.Base], stored_id_field: str, ids: Iterable[str], refresh: bool = False) -> Tuple[int, List[Dict]]:
         """Index (i.e. store) the given vectors at the given index and field with the optional ids.

--- a/client-python/elastiknn/client.py
+++ b/client-python/elastiknn/client.py
@@ -57,7 +57,7 @@ class ElastiknnClient(object):
                 }
             }
         }
-        return self.es.transport.perform_request("PUT", f"/{index}/_mapping", body=body)
+        return self.es.indices.put_mapping(body, index=index)
 
     def index(self, index: str, vec_field: str, vecs: Iterable[Vec.Base], stored_id_field: str, ids: Iterable[str], refresh: bool = False) -> Tuple[int, List[Dict]]:
         """Index (i.e. store) the given vectors at the given index and field with the optional ids.

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -33,8 +33,8 @@ tasks:
     deps:
       - install
     cmds:
-      - venv/bin/python run.py --docker-tag ann-benchmarks-elastiknn --max-n-algorithms 5 --dataset random-xs-20-angular --run-disabled --timeout 300 --local
-      - venv/bin/python run.py --docker-tag ann-benchmarks-elastiknn --max-n-algorithms 5 --dataset random-xs-20-angular --run-disabled --batch --timeout 300 --local
+      - venv/bin/python run.py --algorithm elastiknn-exact --max-n-algorithms 5 --dataset random-xs-20-euclidean --run-disabled --timeout 300 --local --force --runs 1
+      - venv/bin/python run.py --algorithm elastiknn-l2lsh --max-n-algorithms 5 --dataset random-xs-20-euclidean --run-disabled --timeout 300 --local --force --runs 1
       - sudo chmod -R 777 results
       - venv/bin/python plot.py --dataset random-xs-20-angular --output plot.png
 
@@ -46,7 +46,7 @@ tasks:
     cmds:
       - venv/bin/python run.py --dataset fashion-mnist-784-euclidean --algorithm elastiknn-l2lsh --runs 3 --count 100 --parallelism 1 --force
       - sudo chmod -R 777 results/fashion-mnist-784-euclidean/100
-      - venv/bin/python plot.py --dataset fashion-mnist-784-euclidean --output plot-official-fashion-mnist.png
+      - venv/bin/python plot.py --dataset fashion-mnist-784-euclidean --count 100 --output plot-official-fashion-mnist.png
 
   benchmark-local-fashion-mnist:
     desc: Run ann-benchmarks using the local Elastiknn branch.
@@ -56,4 +56,4 @@ tasks:
     cmds:
       - venv/bin/python run.py --dataset sift-128-euclidean --algorithm elastiknn-l2lsh --runs 3 --count 100 --parallelism 1 --force --local
       - sudo chmod -R 777 results/fashion-mnist-784-euclidean/100
-      - venv/bin/python plot.py --dataset sift-128-euclidean --output plot-local-fashion-mnist.png
+      - venv/bin/python plot.py --dataset sift-128-euclidean --count 100 --output plot-local-fashion-mnist.png

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -21,9 +21,10 @@ tasks:
       - python3.6 -m pip install --quiet virtualenv
       - python3.6 -m virtualenv -p python3.6 venv
       - venv/bin/pip install --quiet -r requirements.txt
-      - venv/bin/pip install --quiet elasticsearch==7.17.4 dataclasses-json==0.3.7 tqdm==4.61.1
-      - venv/bin/python install.py --algorithm elastiknn
+      # We need client-python/requirements.txt, but the version of scipy requires Python >= 3.7.
+      - venv/bin/pip install --quiet $(grep -v scipy {{ .PROJECT_ROOT }}/client-python/requirements.txt | xargs)
       - venv/bin/python -c "import importlib; importlib.import_module('ann_benchmarks.algorithms.elastiknn')"
+      - venv/bin/python install.py --algorithm elastiknn
 
   clean:
     desc: Delete artifacts

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -32,11 +32,16 @@ tasks:
     dir: ann-benchmarks
     deps:
       - install
+    env:
+      PYTHONPATH: "$PYTHONPATH:{{ .PROJECT_ROOT }}/client-python"
     cmds:
-      - venv/bin/python run.py --algorithm elastiknn-exact --max-n-algorithms 5 --dataset random-xs-20-euclidean --run-disabled --timeout 300 --local --force --runs 1
-      - venv/bin/python run.py --algorithm elastiknn-l2lsh --max-n-algorithms 5 --dataset random-xs-20-euclidean --run-disabled --timeout 300 --local --force --runs 1
-      - sudo chmod -R 777 results
-      - venv/bin/python plot.py --dataset random-xs-20-angular --output plot.png
+      - sudo rm -rf results/random-xs-20-euclidean
+      - venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
+      - ls results/random-xs-20-euclidean/10/elastiknn-exact
+      - venv/bin/python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
+      - ls results/random-xs-20-euclidean/10/elastiknn-l2lsh
+      - sudo chmod -R 777 results/random-xs-20-euclidean
+      - venv/bin/python plot.py --dataset random-xs-20-euclidean --output plot.png
 
   benchmark-official-fashion-mnist:
     desc: Run ann-benchmarks using released Elastiknn on the SIFT dataset.

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -33,7 +33,7 @@ tasks:
     deps:
       - install
     cmds:
-      - venv/bin/python --version
+      - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python -c "import importlib; importlib.import_module('ann_benchmarks.algorithms.elastiknn')"
       - sudo rm -rf results/random-xs-20-euclidean
       - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-exact

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -33,7 +33,7 @@ tasks:
     deps:
       - install
     env:
-      PYTHONPATH: "$PYTHONPATH:{{ .PROJECT_ROOT }}/client-python"
+      PYTHONPATH: "{{ .PROJECT_ROOT }}/client-python"
     cmds:
       - echo $PYTHONPATH
       - sudo rm -rf results/random-xs-20-euclidean

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -15,13 +15,15 @@ tasks:
     dir: ann-benchmarks
     deps:
       - submodule
+    env:
+      PYTHONPATH: "{{ .PROJECT_ROOT }}/client-python"
     cmds:
-      - pwd
       - python3.6 -m pip install --quiet virtualenv
       - python3.6 -m virtualenv -p python3.6 venv
       - venv/bin/pip install --quiet -r requirements.txt
       - venv/bin/pip install --quiet elasticsearch==7.17.4 dataclasses-json==0.3.7 tqdm==4.61.1
       - venv/bin/python install.py --algorithm elastiknn
+      - venv/bin/python -c "import importlib; importlib.import_module('ann_benchmarks.algorithms.elastiknn')"
 
   clean:
     desc: Delete artifacts
@@ -33,12 +35,13 @@ tasks:
     dir: ann-benchmarks
     deps:
       - install
+    env:
+      PYTHONPATH: "{{ .PROJECT_ROOT }}/client-python"
     cmds:
-      - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python -c "import importlib; importlib.import_module('ann_benchmarks.algorithms.elastiknn')"
       - sudo rm -rf results/random-xs-20-euclidean
-      - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
+      - venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-exact
-      - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
+      - venv/bin/python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-l2lsh
       - sudo chmod -R 777 results/random-xs-20-euclidean
       - venv/bin/python plot.py --dataset random-xs-20-euclidean --output plot.png

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -20,6 +20,7 @@ tasks:
       - python3.6 -m pip install --quiet virtualenv
       - python3.6 -m virtualenv -p python3.6 venv
       - venv/bin/pip install --quiet -r requirements.txt
+      - venv/bin/pip install --quiet dataclasses
       - venv/bin/python install.py --algorithm elastiknn
 
   clean:

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -36,6 +36,7 @@ tasks:
       PYTHONPATH: "{{ .PROJECT_ROOT }}/client-python"
     cmds:
       - echo $PYTHONPATH
+      - venv/bin/python --version
       - sudo rm -rf results/random-xs-20-euclidean
       - venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-exact

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -32,15 +32,12 @@ tasks:
     dir: ann-benchmarks
     deps:
       - install
-    env:
-      PYTHONPATH: "{{ .PROJECT_ROOT }}/client-python"
     cmds:
-      - echo $PYTHONPATH
       - venv/bin/python --version
       - sudo rm -rf results/random-xs-20-euclidean
-      - venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
+      - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-exact
-      - venv/bin/python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
+      - PYTHONPATH="{{ .PROJECT_ROOT }}/client-python" venv/bin/python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-l2lsh
       - sudo chmod -R 777 results/random-xs-20-euclidean
       - venv/bin/python plot.py --dataset random-xs-20-euclidean --output plot.png

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -20,7 +20,7 @@ tasks:
       - python3.6 -m pip install --quiet virtualenv
       - python3.6 -m virtualenv -p python3.6 venv
       - venv/bin/pip install --quiet -r requirements.txt
-      - venv/bin/pip install --quiet dataclasses
+      - venv/bin/pip install --quiet dataclasses elasticsearch==7.17.4
       - venv/bin/python install.py --algorithm elastiknn
 
   clean:

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -20,7 +20,7 @@ tasks:
       - python3.6 -m pip install --quiet virtualenv
       - python3.6 -m virtualenv -p python3.6 venv
       - venv/bin/pip install --quiet -r requirements.txt
-      - venv/bin/pip install --quiet dataclasses elasticsearch==7.17.4
+      - venv/bin/pip install --quiet elasticsearch==7.17.4 dataclasses-json==0.3.7 tqdm==4.61.1
       - venv/bin/python install.py --algorithm elastiknn
 
   clean:

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -35,6 +35,7 @@ tasks:
     env:
       PYTHONPATH: "$PYTHONPATH:{{ .PROJECT_ROOT }}/client-python"
     cmds:
+      - echo $PYTHONPATH
       - sudo rm -rf results/random-xs-20-euclidean
       - venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-exact


### PR DESCRIPTION
## Related Issue

- #387 

## Changes

Ensures that the ann-benchmarks tests are actually running the elastiknn algos. 

Prior to this, elastiknn was _not_ running, as the dataset was set to an angular dataset, and the elastiknn models are only setup for euclidean.

## Testing and Validation

CI