### PR TITLE
#387: Minor benchmarking fixes

### DIFF
--- a/ann-benchmarks/README.md
+++ b/ann-benchmarks/README.md
@@ -49,8 +49,8 @@ This can be any version of Elastiknn, even a remote server, as long as it's avai
 This is particularly useful for testing performance-sensitive changes before merging. 
 
 ```bash
-# Run the local cluster.
-task cluster:run
+# Start the local cluster.
+task cluster:start
 
 # Fashion MNIST dataset.
 task annb:benchmark-local-fashion-mnist

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         circeGenericExtrasVersion= '0.14.1'
         scalaShortVersion = '2.13'
         scalaFullVersion = '2.13.6'
-        zioVersion = '1.0.1'
     }
     repositories {
         maven {

--- a/taskfiles/Taskfile.annb.yaml
+++ b/taskfiles/Taskfile.annb.yaml
@@ -38,6 +38,7 @@ tasks:
       - install
     env:
       PYTHONPATH: "{{ .PROJECT_ROOT }}/client-python"
+      OBJC_DISABLE_INITIALIZE_FORK_SAFETY: "YES"
     cmds:
       - sudo rm -rf results/random-xs-20-euclidean
       - venv/bin/python run.py --algorithm elastiknn-exact --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
@@ -45,7 +46,7 @@ tasks:
       - venv/bin/python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1
       - ls results/random-xs-20-euclidean/10/elastiknn-l2lsh
       - sudo chmod -R 777 results/random-xs-20-euclidean
-      - venv/bin/python plot.py --dataset random-xs-20-euclidean --output plot.png
+      - venv/bin/python plot.py --dataset random-xs-20-euclidean --count 10 --output plot.png
 
   benchmark-official-fashion-mnist:
     desc: Run ann-benchmarks using released Elastiknn on the SIFT dataset.
@@ -62,7 +63,9 @@ tasks:
     dir: ann-benchmarks
     deps:
       - install
+    env:
+      OBJC_DISABLE_INITIALIZE_FORK_SAFETY: "YES"
     cmds:
-      - venv/bin/python run.py --dataset sift-128-euclidean --algorithm elastiknn-l2lsh --runs 3 --count 100 --parallelism 1 --force --local
+      - venv/bin/python run.py --dataset fashion-mnist-784-euclidean --algorithm elastiknn-l2lsh --runs 3 --count 100 --parallelism 1 --force --local
       - sudo chmod -R 777 results/fashion-mnist-784-euclidean/100
-      - venv/bin/python plot.py --dataset sift-128-euclidean --count 100 --output plot-local-fashion-mnist.png
+      - venv/bin/python plot.py --dataset fashion-mnist-784-euclidean --count 100 --output plot-local-fashion-mnist.png


### PR DESCRIPTION
## Related Issue

- #387 

## Changes

- Remove unused variable from build.gradle
- Fix ann-benchmarks dataset name in Taskfile.annb.yaml
- Use `task cluster:start` more consistently in ann-benchmarks/README.md 

## Testing and Validation

Standard CI