### PR TITLE
#400: Set timeouts on github workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   show-github-context:
+    timeout-minutes: 1
     runs-on: ubuntu-20.04
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -18,6 +19,7 @@ jobs:
   
   test-jvm:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -43,6 +45,7 @@ jobs:
       
   test-python:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -67,6 +70,7 @@ jobs:
 
   test-benchmarks:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -93,6 +97,7 @@ jobs:
 
   build-jekyll-site:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Misc. Setup
@@ -105,7 +110,7 @@ jobs:
 
   publish-snapshots:
     runs-on: ubuntu-20.04
-    if: ${{ github.actor == 'alexklibisz' }}
+    timeout-minutes: 10
     needs: [show-github-context, test-jvm, test-python, test-benchmarks]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
 
   release:
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Related Issue

- Resolves #400 

## Changes

Added timeouts on workflow jobs. The original issue seemed to resolve itself. This will just make sure the job doesn't hang indefinitely if it happens again. 

## Testing and Validation

Standard CI