### PR TITLE
#392: Stop publishing JVM libraries

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -3,8 +3,6 @@ set -e
 
 mkdir -p $HOME/.gnupg $HOME/.gradle $HOME/.ssh $HOME/.aws
 
-echo $GPG_SECRET_B64 | base64 --decode > $HOME/.gnupg/secring.gpg
-echo $GRADLE_PROPERTIES_B64 | base64 --decode > $HOME/.gradle/gradle.properties
 echo $PYPIRC_B64 | base64 --decode > $HOME/.pypirc
 echo $SSH_CONFIG_B64 | base64 --decode > $HOME/.ssh/config
 echo $SSH_IDRSA_B64 | base64 --decode > $HOME/.ssh/elastiknn-site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Docs
         run: task jvm:docs
       - name: Publish Local
-        run: task jvm:libraries:publish:local
+        run: task jvm:plugin:publish:local
       - name: Run Cluster
         run: task cluster:run
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,6 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - name: Setup Release Credentials
         env:
-          GPG_SECRET_B64: ${{ secrets.GPG_SECRET_B64 }}
-          GRADLE_PROPERTIES_B64: ${{ secrets.GRADLE_PROPERTIES_B64 }}
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SSH_CONFIG_B64: ${{ secrets.SSH_CONFIG_B64 }}
@@ -138,12 +136,6 @@ jobs:
       - name: Publish to PyPi
         run: task py:publish-snapshot VERSION=$(cat version)-dev${{ github.run_number }}
         if: github.event_name == 'pull_request'
-      - name: Publish JVM Libraries from PR
-        if: github.event_name == 'pull_request'
-        run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-PR${{ github.event.pull_request.number }}-SNAPSHOT
-      - name: Publish JVM Libraries from Master
-        if: github.event_name == 'push'
-        run: task jvm:libraries:publish:snapshot VERSION=$(cat version)-MASTER${{ github.run_number }}-SNAPSHOT
       - name: Publish Plugin from PR
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
           python3 -m pip install setuptools
       - name: Publish Python Docs
         run: task py:publish-docs
-      - name: Publish JVM Docs
-        run: task jvm:docs:publish
       - name: Publish Site
         run: |
           mkdir -p docs/_site
@@ -43,8 +41,6 @@ jobs:
           task docs:publish
       - name: Publish to PyPi
         run: task py:publish-release
-      - name: Publish to Sonatype
-        run: task jvm:libraries:publish:release
       - name: Publish to Github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
           python-version: '3.7.5'
       - name: Setup Release Credentials
         env:
-          GPG_SECRET_B64: ${{ secrets.GPG_SECRET_B64 }}
-          GRADLE_PROPERTIES_B64: ${{ secrets.GRADLE_PROPERTIES_B64 }}
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SSH_CONFIG_B64: ${{ secrets.SSH_CONFIG_B64 }}

--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ Are you using Elastiknn? If so, please consider submitting a pull request to lis
 |:--|:--|:--|:--|
 |Elasticsearch plugin zip file                                                                | [![Plugin Release][Badge-Plugin-Release]][Link-Plugin-Release]          | [![Plugin Snapshot][Badge-Plugin-Snapshot]][Link-Plugin-Snapshot]            | ![Badge-Plugin-Downloads] |
 |Python HTTP client for Elastiknn                                                             | [![Python Release][Badge-Python-Release]][Link-Python-Release]          |                                                                              | ![Badge-Python-Downloads] |
-|Java library w/ exact and approximate vector similarity models                               | [![Models Release][Badge-Models-Release]][Link-Models-Release]          | [![Models Snapshot][Badge-Models-Snapshot]][Link-Models-Snapshot]            |                           |
-|Java library w/ Lucene queries and constructs used in Elastiknn                              | [![Lucene Release][Badge-Lucene-Release]][Link-Lucene-Release]          | [![Lucene Snapshot][Badge-Lucene-Snapshot]][Link-Lucene-Snapshot]            |                           |
-|Scala case classes and circe codecs for the Elastiknn JSON API                               | [![Api4s Release][Badge-Api4s-Release]][Link-Api4s-Release]        	| [![Api4s Snapshot][Badge-Api4s-Snapshot]][Link-Api4s-Snapshot]               |                           |
-|Scala HTTP client for Elastiknn, based on [elastic4s](https://github.com/sksamuel/elastic4s) | [![Elastic4s Release][Badge-Elastic4s-Release]][Link-Elastic4s-Release] | [![Elastic4s Snapshot][Badge-Elastic4s-Snapshot]][Link-Elastic4s-Snapshot]   |                           |
-
 ## Sponsors
 
 [![Yourkit](https://www.yourkit.com/images/yklogo.png)](https://www.yourkit.com/)
@@ -65,23 +60,3 @@ YourKit is the creator of [YourKit Java Profiler](https://www.yourkit.com/java/p
 [Link-Python-Release]: https://pypi.org/project/elastiknn-client/
 [Badge-Python-Release]: https://img.shields.io/pypi/v/elastiknn-client?style=flat-square "Python Release"
 [Badge-Python-Downloads]: https://img.shields.io/pypi/dm/elastiknn-client?style=flat-square
-
-[Badge-Models-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/models?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "models release"
-[Badge-Models-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/models?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "models snapshot"
-[Link-Models-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/models
-[Link-Models-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~models~~~
-
-[Badge-Lucene-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/lucene?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "lucene release"
-[Badge-Lucene-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/lucene?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "lucene snapshot"
-[Link-Lucene-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/lucene
-[Link-Lucene-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~lucene~~~
-
-[Badge-Api4s-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/api4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "api4s_2.12 release"
-[Badge-Api4s-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/api4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "api4s_2.12 snapshot"
-[Link-Api4s-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/api4s_2.12
-[Link-Api4s-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~api4s_2.12~~~
-
-[Badge-Elastic4s-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/client-elastic4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "client-elastic4s_2.12 release"
-[Badge-Elastic4s-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/client-elastic4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "client-elastic4s_2.12 snapshot"
-[Link-Elastic4s-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/client-elastic4s_2.12
-[Link-Elastic4s-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~client-elastic4s_2.12~~~

--- a/build.gradle
+++ b/build.gradle
@@ -81,75 +81,8 @@ def scalaProjectConfig = {
     }
 }
 
-def publishConfig(String projectDescription, boolean isScala = false) {
-    return {
-
-        // Have to do it this way because gradle.properties doesn't expand `~`, `$HOME`, etc.
-        ext."signing.secretKeyRingFile" = "${System.getProperty("user.home")}/.gnupg/secring.gpg"
-
-        apply plugin: 'maven-publish'
-        apply plugin: 'signing'
-        task sourceJar(type: Jar) {
-            classifier 'sources'
-            from sourceSets.main.allSource
-        }
-        task javadocJar(type: Jar) {
-            classifier 'javadoc'
-            from javadoc.destinationDir
-        }
-        publishing {
-            publications {
-                maven(MavenPublication) {
-                    artifactId = isScala ? "${project.name}_${scalaShortVersion}" : project.name
-                    from components.java
-                    artifact tasks.sourceJar
-                    artifact tasks.javadocJar
-                    pom {
-                        groupId = "com.klibisz.elastiknn"
-                        name = "${rootProject.group}:${artifactId}"
-                        description = projectDescription
-                        url = 'https://github.com/alexklibisz/elastiknn'
-                        licenses {
-                            license {
-                                name = 'Apache 2.0'
-                                url = 'https://choosealicense.com/licenses/apache-2.0/'
-                            }
-                        }
-                        developers {
-                            developer {
-                                id = 'alexklibisz'
-                                name = 'Alex Klibisz'
-                                email = 'aklibisz@gmail.com'
-                            }
-                        }
-                        scm {
-                            connection = 'scm:git:git://github.com/alexklibisz/elastiknn.git'
-                            developerConnection = 'scm:git:ssh://github.com/alexklibisz/elastiknn.git'
-                            url = 'https://github.com/alexklibisz/elastiknn'
-                        }
-                    }
-
-                }
-            }
-            repositories {
-                maven {
-                    url = version.contains('SNAPSHOT') ? "https://oss.sonatype.org/content/repositories/snapshots/" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-                    credentials {
-                        username = project.properties.getOrDefault('sonatypeUsername', 'wrong')
-                        password = project.properties.getOrDefault('sonatypePassword', 'wrong')
-                    }
-                }
-            }
-        }
-        signing {
-            sign publishing.publications
-        }
-    }
-}
-
 configure(api4s, List.of(
         scalaProjectConfig,
-        publishConfig("Scala case classes and JSON codecs for the Elastiknn JSON API", true),
         {
             dependencies {
                 implementation "org.elasticsearch:elasticsearch-x-content:${esVersion}"
@@ -160,7 +93,6 @@ configure(api4s, List.of(
 
 configure(clientElastic4s, List.of(
         scalaProjectConfig,
-        publishConfig("Scala client for Elastiknn, based on elastic4s", true),
         {
             dependencies {
                 api api4s
@@ -169,11 +101,9 @@ configure(clientElastic4s, List.of(
             }
         }))
 
-configure(models, List.of(
-        publishConfig("Exact and approximate similarity models used in Elastiknn", false)))
+configure(models, Collections.emptyList())
 
 configure(lucene, List.of(
-        publishConfig("Custom Lucene queries used in Elastiknn"),
         {
             dependencies {
                 implementation models

--- a/docs/pages/libraries.md
+++ b/docs/pages/libraries.md
@@ -8,8 +8,6 @@ toc_label: Contents
 toc_icon: cog
 ---
 
-The Elastiknn project includes some additional Python, Java, and Scala libraries.
-
 ## Python client
 
 
@@ -30,119 +28,7 @@ This includes a low level client that roughly mirrors the [Scala client](/scala-
 |:--|:--|
 |Release|[![Python Release][Badge-Python-Release]][Link-Python-Release]|
 
-## Java library with exact and approximate nearest neighbor search models
-
-This library contains the exact and approximate nearest neighbor search models used by Elastiknn.
-
-**Install**
-
-In a Gradle project:
-
-```groovy
-implementation 'com.klibisz.elastiknn:models:<version below>'
-```
-
-**Versions**
-
-|:--|:--|
-|Release|[![Models Release][Badge-Models-Release]][Link-Models-Release]|
-|Snapshot|[![Models Snapshot][Badge-Models-Snapshot]][Link-Models-Snapshot]|
-
-
-## Java library with custom Lucene queries
-
-This library contains a custom Lucene query used by Elastiknn, as well as a handful of related utilities.
-
-**Install**
-
-In a Gradle project:
-
-```groovy
-implementation 'com.klibisz.elastiknn:lucene:<version below>'
-```
-
-**Versions**
-
-|:--|:--|
-|Release|[![Lucene Release][Badge-Lucene-Release]][Link-Lucene-Release]|
-|Snapshot|[![Lucene Snapshot][Badge-Lucene-Snapshot]][Link-Lucene-Snapshot]|
-
-## Scala client
-
-The Scala client provides type-safe, asynchronous methods for using the Elastiknn plugin from your Scala project.
-It's built on top of the popular [elastic4s library](https://github.com/sksamuel/elastic4s) and abstracts over effect types.
-A default instance for Scala `Future`s ships with the client.
-
-**Install**
-
-In an sbt project:
-
-```scala
-libraryDependencies += "com.klibisz.elastiknn" %% "client-elastic4s" % <version below>
-```
-
-**Documentation**
-
-- **<a href="/docs/scaladoc/com/klibisz/elastiknn/client/" target="_blank">Scaladocs for the latest release</a>**
-- <a href="https://archive.elastiknn.com" target="_blank">Archived docs from previous releases</a>
-
-**Versions**
-
-|:--|:--|
-|Release| [![Elastic4s Release][Badge-Elastic4s-Release]][Link-Elastic4s-Release] | 
-|Snapshot| [![Elastic4s Snapshot][Badge-Elastic4s-Snapshot]][Link-Elastic4s-Snapshot]|
-
-## Scala case classes and codecs for the JSON API
-
-This library contains case classes and [Circe](https://github.com/circe/circe) codecs for the data structures in Elastiknn's JSON API.
-
-**Install**
-
-In an sbt project:
-
-```scala
-libraryDependencies += "com.klibisz.elastiknn" %% "api4s" % <version below>
-```
-
-**Versions**
-
-|:--|:--|
-|Release|[![Api4s Release][Badge-Api4s-Release]][Link-Api4s-Release]|
-|Snapshot|[![Api4s Snapshot][Badge-Api4s-Snapshot]][Link-Api4s-Snapshot]|
-
-
 <!-- Links -->
-
-[Link-Github-CI]: https://github.com/alexklibisz/elastiknn/actions?query=workflow%3ACI
-[Badge-Github-CI]: https://img.shields.io/github/workflow/status/alexklibisz/elastiknn/CI?style=for-the-badge "Github CI Workflow"
-
-[Link-Github-Release]: https://github.com/alexklibisz/elastiknn/actions?query=workflow%3ARelease
-[Badge-Github-Release]: https://img.shields.io/github/workflow/status/alexklibisz/elastiknn/Release?style=for-the-badge "Github Release Workflow"
-
-[Link-Plugin-Release]: https://github.com/alexklibisz/elastiknn/releases/latest
-[Badge-Plugin-Release]: https://img.shields.io/github/v/release/alexklibisz/elastiknn?style=flat-square "Plugin Release"
-[Link-Plugin-Snapshot]: https://github.com/alexklibisz/elastiknn/releases
-[Badge-Plugin-Snapshot]: https://img.shields.io/github/v/release/alexklibisz/elastiknn?include_prereleases&style=flat-square "Plugin Snapshot"
 
 [Link-Python-Release]: https://pypi.org/project/elastiknn-client/
 [Badge-Python-Release]: https://img.shields.io/pypi/v/elastiknn-client?style=flat-square "Python Release"
-
-[Badge-Models-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/models?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "models release"
-[Badge-Models-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/models?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "models snapshot"
-[Link-Models-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/models
-[Link-Models-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~models~~~
-
-[Badge-Lucene-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/lucene?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "lucene release"
-[Badge-Lucene-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/lucene?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "lucene snapshot"
-[Link-Lucene-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/lucene
-[Link-Lucene-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~lucene~~~
-
-[Badge-Api4s-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/api4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "api4s_2.12 release"
-[Badge-Api4s-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/api4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "api4s_2.12 snapshot"
-[Link-Api4s-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/api4s_2.12
-[Link-Api4s-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~api4s_2.12~~~
-
-[Badge-Elastic4s-Release]: https://img.shields.io/nexus/r/com.klibisz.elastiknn/client-elastic4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "client-elastic4s_2.12 release"
-[Badge-Elastic4s-Snapshot]: https://img.shields.io/nexus/s/com.klibisz.elastiknn/client-elastic4s_2.12?server=http%3A%2F%2Foss.sonatype.org&style=flat-square "client-elastic4s_2.12 snapshot"
-[Link-Elastic4s-Release]: https://search.maven.org/artifact/com.klibisz.elastiknn/client-elastic4s_2.12
-[Link-Elastic4s-Snapshot]: https://oss.sonatype.org/#nexus-search;gav~com.klibisz.elastiknn~client-elastic4s_2.12~~~

--- a/taskfiles/Taskfile.jvm.yaml
+++ b/taskfiles/Taskfile.jvm.yaml
@@ -30,32 +30,6 @@ tasks:
     cmds:
       - "{{ .CMD_GRADLE }} publishToMavenLocal -x signMavenPublication -Pversion={{ .VERSION }}"
 
-  libraries:publish:snapshot:
-    desc: Publish a snapshot release of JVM libraries to Sonatype
-    cmds:
-      - "{{ .CMD_GRADLE }} publish -Pversion={{ .VERSION }}"
-
-  libraries:publish:release:
-    desc: Publish an official release of JVM libraries to Sonatype
-    # Checks that none of the libraries have been published yet.
-    status:
-      - curl -f -s -o /dev/null {{ .MAVEN_URL }}/lucene/{{ .VERSION }}/lucene-{{ .VERSION }}.pom
-      - curl -f -s -o /dev/null {{ .MAVEN_URL }}/client-elastic4s_2.13/{{ .VERSION }}/client-elastic4s_2.13-{{ .VERSION }}.pom
-      - curl -f -s -o /dev/null {{ .MAVEN_URL }}/api4s_2.13/{{ .VERSION }}/api4s_2.13-{{ .VERSION }}.pom
-    cmds:
-      - "{{ .CMD_GRADLE }} publish"
-
-  docs:publish:
-    desc: Publish documentation to the website
-    status:
-      - curl -f -s -o /dev/null https://{{ .SITE_ARCH_DIR }}/{{ .VERSION }}/scaladoc/index.html
-    cmds:
-      - "{{ .CMD_GRADLE }} unifiedScaladocs"
-      - ssh {{ .SITE_SSH_ALIAS }} mkdir -p {{ .SITE_ARCH_DIR }}/{{ .VERSION }}
-      - rsync -av --delete build/docs/scaladoc {{ .SITE_SSH_ALIAS }}:{{ .SITE_ARCH_DIR }}/{{ .VERSION }}
-      - ssh {{ .SITE_SSH_ALIAS }} mkdir -p {{ .SITE_MAIN_DIR }}/{{ .VERSION }}
-      - rsync -av --delete build/docs/scaladoc {{ .SITE_SSH_ALIAS }}:{{ .SITE_MAIN_DIR }}/docs
-
   plugin:publish:local:
     desc: Publish a local snapshot of the plugin
     sources:

--- a/taskfiles/Taskfile.jvm.yaml
+++ b/taskfiles/Taskfile.jvm.yaml
@@ -25,11 +25,6 @@ tasks:
     cmds:
       - "{{ .CMD_GRADLE }} test"
 
-  libraries:publish:local:
-    desc: Publish a local release of JVM libraries
-    cmds:
-      - "{{ .CMD_GRADLE }} publishToMavenLocal -x signMavenPublication -Pversion={{ .VERSION }}"
-
   plugin:publish:local:
     desc: Publish a local snapshot of the plugin
     sources:


### PR DESCRIPTION
## Related Issue

- Resolves #392 

## Changes

Removed publish configuration and automation for all JVM libraries: com.klibisz.elastiknn:models, com.klibisz.elastiknn:lucene, com.klibisz.elastiknn:client-elastic4s_2.13, com.klibisz.elastiknn:api4s_2.13 

## Testing and Validation

Standard CI