### PR TITLE
Build: Upgrade setup-java action and add Gradle caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 17
           cache: 'gradle'
       - name: Misc. Setup
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 17
           cache: 'gradle'
       - uses: actions/setup-python@v2
@@ -77,6 +79,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 17
           cache: 'gradle'
       - uses: actions/setup-python@v2
@@ -128,6 +131,7 @@ jobs:
         run: ./.github/scripts/setup-env.sh
       - uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 17
           cache: 'gradle'
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          cache: 'gradle'
       - name: Misc. Setup
         run: |
           sudo snap install task --classic
@@ -48,9 +49,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          cache: 'gradle'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.5'
@@ -73,9 +75,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          cache: 'gradle'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.6'
@@ -123,9 +126,10 @@ jobs:
           SSH_CONFIG_B64: ${{ secrets.SSH_CONFIG_B64 }}
           SSH_IDRSA_B64: ${{ secrets.SSH_IDRSA_B64 }}
         run: ./.github/scripts/setup-env.sh
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          cache: 'gradle'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.5'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 17
           cache: 'gradle'
       - uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+
 name: Release
 on:
   push:
@@ -13,9 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Needed for git-based changelog.
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          cache: 'gradle'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.5'


### PR DESCRIPTION
## Related Issue

Noticed that some builds are failing to resolve dependencies from bintray:

- https://github.com/alexklibisz/elastiknn/actions/runs/3085494976/jobs/4988848293
- https://github.com/alexklibisz/elastiknn/actions/runs/3085494979/jobs/4988847979

## Changes

- Upgrade setup-java Github action from v1 to v3
- Add Gradle caching

## Testing and Validation

How was it validated?

- Standard CI