### PR TITLE
Build: re-build the cache for every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
             ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
-            ci-${{ github.job }}-master
           path: |
             **/target/**/*
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
-      - name: Debug cache
-        run: |
-          echo ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
-          echo ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
       - uses: actions/cache@v3
         with:
           key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
             ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+            ci-${{ github.job }}-master
           path: |
             **/target/**/*
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,11 @@ jobs:
         run: task cluster:run
       - name: Test
         run: sbt testQuick
+      - name: Stop Cluster
+        if: always()
+        run: task cluster:stop
       - name: Cluster Logs
-        if: failure()
+        if: always()
         run: task cluster:logs
       
   test-python:
@@ -62,6 +65,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v3
+        with:
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          restore-keys: |
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+          path: |
+            **/target/**/*
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -71,13 +82,6 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - uses: actions/cache@v3
-        with:
-          key: ci-${{ github.job }}-${{ github.ref_name }}
-          restore-keys: |
-            ci-${{ github.job }}-master
-          path: |
-            **/target/**/*
       - name: Misc. Setup
         run: |
          sudo snap install task --classic
@@ -89,7 +93,7 @@ jobs:
       - name: Test
         run: task py:test
       - name: Cluster Logs
-        if: failure()
+        if: always()
         run: task cluster:logs
 
   test-benchmarks:
@@ -97,6 +101,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v3
+        with:
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          restore-keys: |
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+          path: |
+            **/target/**/*
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -106,13 +118,6 @@ jobs:
         with:
           python-version: '3.6'
           cache: 'pip'
-      - uses: actions/cache@v3
-        with:
-          key: ci-${{ github.job }}-${{ github.ref_name }}
-          restore-keys: |
-            ci-${{ github.job }}-master
-          path: |
-            **/target/**/*
       - name: Misc. Setup
         run: |
           sudo snap install task --classic
@@ -126,7 +131,7 @@ jobs:
       - name: Test
         run: task annb:test
       - name: Cluster Logs
-        if: failure()
+        if: always()
         run: task cluster:logs
 
   build-jekyll-site:
@@ -150,6 +155,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Needed for git-based changelog.
+      - uses: actions/cache@v3
+        with:
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          restore-keys: |
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+          path: |
+            **/target/**/*
       - name: Setup Release Credentials
         env:
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
@@ -166,14 +179,8 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - uses: actions/cache@v3
-        with:
-          key: ci-${{ github.job }}-${{ github.ref_name }}
-          restore-keys: |
-            ci-${{ github.job }}-master
-          path: |
-            **/target/**/*
-      - run: |
+      - name: Misc. Setup
+        run: |
           sudo snap install task --classic
           sudo snap install hub --classic
           python3 -m pip install setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: 17
-          cache: 'sbt'
+      - name: Debug cache
+        run: |
+          echo ${{ github.workflow }}
+          echo ${{ github.ref }}
+          echo ${{ github.ref_name }}
+          echo ${{ github.event.before }}
+          echo ${{ github.event.after }}
       - uses: actions/cache@v3
         with:
           key: ci-${{ github.job }}-${{ github.ref_name }}
@@ -34,6 +36,11 @@ jobs:
             ci-${{ github.job }}-master
           path: |
             **/target/**/*
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 17
+          cache: 'sbt'
       - name: Misc. Setup
         run: |
           sudo snap install task --classic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Debug cache
         run: |
-          echo ${{ github.workflow }}
-          echo ${{ github.ref }}
-          echo ${{ github.ref_name }}
-          echo ${{ github.event.before }}
-          echo ${{ github.event.after }}
+          echo ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+          echo ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
       - uses: actions/cache@v3
         with:
           key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
           echo ${{ github.event.after }}
       - uses: actions/cache@v3
         with:
-          key: ci-${{ github.job }}-${{ github.ref_name }}
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
           restore-keys: |
-            ci-${{ github.job }}-master
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
           path: |
             **/target/**/*
       - uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Needed for git-based changelog.
-      - uses: actions/setup-java@v3
+      - uses: actions/cache@v3
         with:
-          distribution: 'adopt'
-          java-version: 17
-          cache: 'sbt'
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          restore-keys: |
+            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+          path: |
+            **/target/**/*
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - uses: actions/cache@v3
-        with:
-          key: ci-${{ github.job }}-${{ github.ref_name }}
-          restore-keys: |
-            ci-${{ github.job }}-master
-          path: |
-            **/target/**/*
       - name: Setup Release Credentials
         env:
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}


### PR DESCRIPTION
## Related Issue

- #360 

## Changes

- Re-build the cache for every commit by keying on the commit name instead of the branch name. The previous strategy used the branch name in the key. But, if an entry already exists in the cache, it won't be overridden. Github will just continue pulling the older entry. That means it keeps pulling the 7-day old master-branch entry when running for a push to master, and keeps pulling the first entry from a given branch when running for a PR. To solve this, we can key on the commit sha, with a fallback to the previous commit sha. This will create more churn in the cache, but it doesn't really matter since Github cleans all of that up.

## Testing and Validation

How was it validated?