### PR TITLE
Build: reinstate RecallSuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ jobs:
   
   test-jvm:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
+      - name: Debug
+        run: |
+          cat /proc/cpuinfo
       - uses: actions/cache@v3
         with:
           key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
-      - name: Debug
-        run: |
-          cat /proc/cpuinfo
       - uses: actions/cache@v3
         with:
           key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xmx4096M
+-J-Xmx1024M
 -J-Xms1024M
 -J-XX:+UseG1GC

--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ lazy val `elastiknn-testing` = project
   .dependsOn(`elastiknn-client-elastic4s`, `elastiknn-plugin`)
   .settings(
     Test / parallelExecution := false,
+    Test / logBuffered := false,
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-generic-extras" % CirceGenericExtrasVersion,
       "io.circe" %% "circe-parser" % CirceVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,7 @@ lazy val `elastiknn-testing` = project
   .settings(
     Test / parallelExecution := false,
     Test / logBuffered := false,
+    Test / testOptions += Tests.Argument("-oD"),
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-generic-extras" % CirceGenericExtrasVersion,
       "io.circe" %% "circe-parser" % CirceVersion,

--- a/elastiknn-testing/docker-compose.yml
+++ b/elastiknn-testing/docker-compose.yml
@@ -2,7 +2,7 @@
 # Github's virtual environments have 2 CPUs, 7GB memory, 14GB SSD.
 # Important to run > 1 node because some parts of the plugin
 # deal with communication/serialization between nodes.
-version: "3.8"
+version: "2"
 
 services:
   # Single master node.
@@ -23,6 +23,9 @@ services:
       - ES_JAVA_OPTS=-Xms700m -Xmx700m
     ports:
       - "9200:9200"
+    mem_limit: 1000m
+    mem_reservation: 1000m
+    cpus: 0.5
     ulimits:
       nofile:
         soft: 65536
@@ -43,9 +46,12 @@ services:
       - discovery.seed_hosts=elasticsearch_master
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms4G -Xmx4G -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=8097 -Dcom.sun.management.jmxremote.rmi.port=8097 -Djava.rmi.server.hostname=localhost
+      - ES_JAVA_OPTS=-Xms700m -Xmx700m -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=8097 -Dcom.sun.management.jmxremote.rmi.port=8097 -Djava.rmi.server.hostname=localhost
     ports:
       - "8097:8097"
+    mem_limit: 1000m
+    mem_reservation: 1000m
+    cpus: 1
     ulimits:
       nofile:
         soft: 65536

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -6,7 +6,6 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Response
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import futil.Futil
-import org.scalatest.DoNotDiscover
 import org.scalatest.concurrent.AsyncCancelAfterFailure
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
+++ b/elastiknn-testing/src/test/scala/com/klibisz/elastiknn/query/RecallSuite.scala
@@ -26,7 +26,6 @@ import scala.util.hashing.MurmurHash3.orderedHash
   *   the same query, I have seen different results at times. This seems to be an effect at the Elasticsearch level.
   *   I've tested at the Lucene (sans ES) level and that seems to be reliably deterministic.
   */
-@DoNotDiscover
 class RecallSuite extends AsyncFunSuite with Matchers with ElasticAsyncClient with AsyncCancelAfterFailure {
 
   // Each test case consists of setting up one Mapping and then running several queries against that mapping.


### PR DESCRIPTION
## Related Issue

- #400 

## Changes

- Remove DoNotDiscover from RecallSuite
- Explicit limits on memory for the docker containers.

## Testing and Validation

- Standard CI