### PR TITLE
Build: cache on run_number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
           restore-keys: |
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+            ${{ github.workflow }}.${{ github.job }}
           path: |
             **/target/**/*
       - uses: actions/setup-java@v3
@@ -60,10 +59,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
           restore-keys: |
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+            ${{ github.workflow }}.${{ github.job }}
           path: |
             **/target/**/*
       - uses: actions/setup-java@v3
@@ -96,10 +94,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
           restore-keys: |
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
+            ${{ github.workflow }}.${{ github.job }}
           path: |
             **/target/**/*
       - uses: actions/setup-java@v3
@@ -150,12 +147,9 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
           restore-keys: |
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.pull_request.base.sha }}
-          path: |
-            **/target/**/*
+            ${{ github.workflow }}.${{ github.job }}
       - name: Setup Release Credentials
         env:
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
@@ -191,4 +185,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/scripts/delete-snapshot-releases.sh
-          task jvm:plugin:publish:snapshot VERSION=$(cat version)-MAIN{{ github.run_number }}-SNAPSHOT
+          task jvm:plugin:publish:snapshot VERSION=$(cat version)-MAIN${{ github.run_number }}-SNAPSHOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
+          key: ${{ github.workflow }}.${{ github.job }}.r${{ github.run_number }}
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}
           path: |
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
+          key: ${{ github.workflow }}.${{ github.job }}.r${{ github.run_number }}
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}
           path: |
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
+          key: ${{ github.workflow }}.${{ github.job }}.r${{ github.run_number }}
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}
           path: |
@@ -147,7 +147,7 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
+          key: ${{ github.workflow }}.${{ github.job }}.r${{ github.run_number }}
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}
       - name: Setup Release Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
           key: ${{ github.workflow }}.${{ github.job }}.r${{ github.run_number }}
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}
+          path: |
+            **/target/**/*
       - name: Setup Release Credentials
         env:
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
+          key: ${{ github.workflow }}.${{ github.job }}.r${{ github.run_number }}
           restore-keys: |
             ${{ github.workflow }}.${{ github.job }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/cache@v3
         with:
-          key: ${{ github.workflow }}.${{ github.job }}.${{ github.event.after }}
+          key: ${{ github.workflow }}.${{ github.job }}.${{ github.run_number }}
           restore-keys: |
-            ${{ github.workflow }}.${{ github.job }}.${{ github.event.before }}
+            ${{ github.workflow }}.${{ github.job }}
           path: |
             **/target/**/*
       - uses: actions/setup-python@v2


### PR DESCRIPTION
## Related Issue

#420 

## Changes

Cache on the run number instead of the sha. Based on trick from here: https://github.com/actions/cache/issues/2#issuecomment-1259332802

## Testing and Validation

Standard CI