### PR TITLE
Build: make the release workflow runnable from Actions tab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches: 
       - main
 
+  workflow_dispatch:
+
 jobs:
 
   release:


### PR DESCRIPTION
## Related Issue

- #442 

## Changes

Add workflow_dispatch to on section in release.yaml to make the workflow runnable from the actions tab.

## Testing and Validation

See if it works in actions tab