### PR TITLE
Build: fix permissions on docs directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Generate Site
         run: |
           sudo snap install task --classic
+          mkdir -p docs/_site
+          chmod -R 777 docs
           task docs:compile
       - name: Configure Pages
         uses: actions/configure-pages@v2


### PR DESCRIPTION
## Related Issue

#442 

## Changes

chmod 777 on the docs directory before compiling. For some reason the Jekyll container needs this when running in Github actions.

## Testing and Validation

Re-run after merging.