### PR TITLE
Build: fix permissions on Github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ on:
 
   workflow_dispatch:
 
-jobs:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
+jobs:
   release-docs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10


### PR DESCRIPTION
## Related Issue

- #442 

## Changes

Set token permissions to address this error:

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/8015228/196189532-f273eca1-f08c-4cb1-9185-abd83b46b6e1.png">

## Testing and Validation

Re-run after merging