### PR TITLE
Build: Publish Python docs to Github pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Generate Site
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7.5'
+          cache: 'pip'
+      - name: Generate Jekyll Site
         run: |
           sudo snap install task --classic
           mkdir -p docs/_site
           chmod -R 777 docs
           task docs:compile
+      - name: Generate Python Docs
+        run: |
+          task py:docs
+          mkdir -p docs/_site/docs
+          mv client-python/pdoc/elastiknn docs/_site/docs/pdoc
       - name: Configure Pages
         uses: actions/configure-pages@v2
       - name: Upload Pages Artifact

--- a/docs/pages/libraries.md
+++ b/docs/pages/libraries.md
@@ -10,9 +10,8 @@ toc_icon: cog
 
 ## Python client
 
-
 The Python client provides a pythonic interface for using Elastiknn.
-This includes a low level client that roughly mirrors the [Scala client](/scala-client), as well as a higher level "model" that mimics the scikit-learn interface.
+This includes a low level HTTP client as well as a higher level "model" that mimics the scikit-learn interface.
 
 **Install**
 
@@ -20,8 +19,7 @@ This includes a low level client that roughly mirrors the [Scala client](/scala-
 
 **Documentation**
 
-- **<a href="/docs/pdoc" target="_blank">PDoc for latest release</a>**
-- <a href="https://archive.elastiknn.com" target="_blank">Archived docs from previous releases</a>
+- **<a href="/docs/pdoc" target="_blank">Docs for latest release</a>**
 
 **Versions**
 

--- a/taskfiles/Taskfile.python.yaml
+++ b/taskfiles/Taskfile.python.yaml
@@ -50,6 +50,7 @@ tasks:
     cmds:
       - rm -rf pdoc
       - venv/bin/pdoc3 --html elastiknn -c show_type_annotations=True -o pdoc
+      - ls -la pdoc/elastiknn
     
   publish-local:
     desc: Publish python library locally
@@ -66,18 +67,6 @@ tasks:
       - task: publish-local
         force: True
       - venv/bin/python -m twine upload -r testpypi --verbose dist/*
-
-  publish-docs:
-    desc: Publish python docs to elastiknn.com server
-    status:
-      - curl -f -s -o /dev/null https://{{ .SITE_ARCH_DIR }}/{{ .VERSION }}/pdoc/index.html
-    cmds:
-      - task: docs
-        force: True
-      - ssh {{ .SITE_SSH_ALIAS }} mkdir -p {{ .SITE_ARCH_DIR }}/{{ .VERSION }}
-      - rsync -av --delete pdoc/elastiknn/ {{ .SITE_SSH_ALIAS }}:{{ .SITE_ARCH_DIR }}/{{ .VERSION }}/pdoc
-      - rsync -av --delete pdoc/elastiknn/ {{ .SITE_SSH_ALIAS }}:{{ .SITE_MAIN_DIR }}/docs/pdoc
-    
 
   publish-release:
     desc: Publish python library to pypi


### PR DESCRIPTION
## Related Issue

- #442 

## Changes

- Fix some text in the libraries page
- Publish the python docs to github pages

## Testing and Validation

- Will run release post-merge