### PR TITLE
Build: Use ubuntu-20.04 to generate docs and remove Publish Python Docs step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     environment:
       name: github-pages
@@ -80,8 +80,6 @@ jobs:
       - run: |
           sudo snap install task --classic
           python3 -m pip install setuptools
-      - name: Publish Python Docs
-        run: task py:publish-docs
       - name: Publish Site
         run: |
           mkdir -p docs/_site


### PR DESCRIPTION
## Related Issue

- #442 

## Changes

Ubuntu 22 doesn't seem to support python 3.7.5. Probably best to update to newer ubuntu as a separate task.

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/8015228/197773784-b0684654-3e19-477a-8378-d2dac858175f.png">

Also no longer need the "Publish Python Docs" step in the main release.

## Testing and Validation

Merge-and-check