### PR TITLE
Build: upgrade workflows from ubuntu-20.04 to ubuntu-22.04 where possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,9 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - name: Setup SBT
-        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - uses: jtalk/setup-sbt@v2
+        with:
+          version: 1.8.0
       - name: Setup Task
         uses: arduino/setup-task@v1
       - name: Misc. Setup
@@ -85,8 +86,9 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - name: Setup SBT
-        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - uses: jtalk/setup-sbt@v2
+        with:
+          version: 1.8.0
       - name: Setup Task
         uses: arduino/setup-task@v1
       - name: Misc. Setup
@@ -122,8 +124,9 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - name: Setup SBT
-        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - uses: jtalk/setup-sbt@v2
+        with:
+          version: 1.8.0
       - name: Setup Task
         uses: arduino/setup-task@v1
       - uses: actions/setup-python@v2
@@ -187,8 +190,9 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - name: Setup SBT
-        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - uses: jtalk/setup-sbt@v2
+        with:
+          version: 1.8.0
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.5'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - uses: jtalk/setup-sbt@v2
-        with:
-          version: 1.8.0
       - uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -90,9 +87,6 @@ jobs:
         with:
           python-version: '3.7.15'
           cache: 'pip'
-      - uses: jtalk/setup-sbt@v2
-        with:
-          version: 1.8.0
       - uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -131,9 +125,6 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - uses: jtalk/setup-sbt@v2
-        with:
-          version: 1.8.0
       - uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -201,9 +192,6 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - uses: jtalk/setup-sbt@v2
-        with:
-          version: 1.8.0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7.15'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
       - uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
+          sudo whoami
+          whoami
           sudo chown -R runneradmin:runneradmin docs
           task docsCompile
           sudo chown -R runner:docker docs 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
   test-benchmarks:
     name: Test Benchmarks
     runs-on:
-      - ubuntu-22.04
+      # Has to remain on ubuntu 20 and python 3.6 until ann-benchmarks is upgraded.
+      - ubuntu-20.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7.5'
           cache: 'pip'
@@ -129,7 +129,7 @@ jobs:
           version: 1.8.0
       - name: Setup Task
         uses: arduino/setup-task@v1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.6'
           cache: 'pip'
@@ -193,7 +193,7 @@ jobs:
       - uses: jtalk/setup-sbt@v2
         with:
           version: 1.8.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7.5'
           cache: 'pip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,10 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
+      - name: Install Task
+        uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: |
-          sudo snap install task --classic
           sudo sysctl -w vm.max_map_count=262144
       - name: Compile
         run: |
@@ -82,9 +83,10 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
+      - name: Install Task
+        uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: |
-         sudo snap install task --classic
          sudo sysctl -w vm.max_map_count=262144
       - name: Docs
         run: task pyDocs
@@ -121,9 +123,10 @@ jobs:
         with:
           python-version: '3.6'
           cache: 'pip'
+      - name: Install Task
+        uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: |
-          sudo snap install task --classic
           sudo sysctl -w vm.max_map_count=262144
       - name: Initialize Submodule
         run: task annbCreateSubmodule
@@ -146,9 +149,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - name: Misc. Setup
-        run: |
-          sudo snap install task --classic
+      - name: Install Task
+        uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
           sudo chown -R runneradmin:runneradmin docs
@@ -185,9 +187,10 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
+      - name: Install Task
+        uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: |
-          sudo snap install task --classic
           python3 -m pip install setuptools
       - name: Publish to PyPi
         run: task pyPublishSnapshot VERSION=$(cat version)-dev${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
   show-github-context:
     name: "Show Github Context"
     timeout-minutes: 1
-    runs-on: self-hosted
+    runs-on:
+      - ubuntu-22.04
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:
@@ -24,7 +25,8 @@ jobs:
   
   test-jvm:
     name: "Test JVM Code"
-    runs-on: self-hosted
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
@@ -43,9 +45,8 @@ jobs:
       - uses: jtalk/setup-sbt@v2
         with:
           version: 1.8.0
-      - name: Setup Task
-        uses: arduino/setup-task@v1
-      - name: Misc. Setup
+      - uses: arduino/setup-task@v1
+      - name: Increase MMAP Limits
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Compile
         run: task jvmCompile
@@ -66,7 +67,8 @@ jobs:
       
   test-python:
     name: Test Python Code
-    runs-on: ubuntu-20.04
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -89,9 +91,8 @@ jobs:
       - uses: jtalk/setup-sbt@v2
         with:
           version: 1.8.0
-      - name: Setup Task
-        uses: arduino/setup-task@v1
-      - name: Misc. Setup
+      - uses: arduino/setup-task@v1
+      - name: Increase MMAP Limits
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Docs
         run: task pyDocs
@@ -108,7 +109,8 @@ jobs:
 
   test-benchmarks:
     name: Test Benchmarks
-    runs-on: ubuntu-20.04
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -127,13 +129,12 @@ jobs:
       - uses: jtalk/setup-sbt@v2
         with:
           version: 1.8.0
-      - name: Setup Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - uses: actions/setup-python@v4
         with:
           python-version: '3.6'
           cache: 'pip'
-      - name: Misc. Setup
+      - name: Increase MMAP Limits
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Initialize Submodule
         run: task annbCreateSubmodule
@@ -152,12 +153,12 @@ jobs:
 
   build-jekyll-site:
     name: Test Jekyll Site
-    runs-on: ubuntu-20.04
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
           sudo chown -R runneradmin:runneradmin docs
@@ -167,7 +168,8 @@ jobs:
 
   publish-snapshots:
     name: Publish Snapshots
-    runs-on: ubuntu-20.04
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 10
     needs: [show-github-context, test-jvm, test-python, test-benchmarks]
     steps:
@@ -197,8 +199,7 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - name: Setup Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - name: Setup Setuptools
         run: python3 -m pip install setuptools
       - name: Publish to PyPi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           version: 1.8.0
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Increase MMAP Limits
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Compile
@@ -92,6 +94,8 @@ jobs:
         with:
           version: 1.8.0
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Increase MMAP Limits
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Docs
@@ -131,6 +135,8 @@ jobs:
         with:
           version: 1.8.0
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v4
         with:
           python-version: '3.6'
@@ -160,6 +166,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
         run: |
           sudo chown -R runneradmin:runneradmin docs
@@ -201,6 +209,8 @@ jobs:
           python-version: '3.7.15'
           cache: 'pip'
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Setuptools
         run: python3 -m pip install setuptools
       - name: Publish to PyPi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
-          sudo chown -R root:root docs
+          sudo chown -R runneradmin:runneradmin docs
           task docsCompile
           sudo chown -R runner:docker docs 
           ls -la docs/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           cache: 'sbt'
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.5'
+          python-version: '3.7.15'
           cache: 'pip'
       - uses: jtalk/setup-sbt@v2
         with:
@@ -197,7 +197,7 @@ jobs:
           version: 1.8.0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.5'
+          python-version: '3.7.15'
           cache: 'pip'
       - uses: arduino/setup-task@v1
       - name: Setup Setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,14 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - name: Install Task
-        uses: arduino/setup-task@v1
+      - uses: olafurpg/setup-scala@v11
+      - uses: arduino/setup-task@v1
       - name: Misc. Setup
-        run: |
-          sudo sysctl -w vm.max_map_count=262144
+        run: sudo sysctl -w vm.max_map_count=262144
       - name: Compile
-        run: |
-          sbt update compile Test/compile elasticsearchPluginBundle
+        run: sbt jvmCompile
+      - name: Assemble
+        run: sbt jvmAssemble
       - name: Run Unit Tests
         run: task jvmUnitTestQuick
       - name: Run Cluster
@@ -83,11 +83,9 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - name: Install Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - name: Misc. Setup
-        run: |
-         sudo sysctl -w vm.max_map_count=262144
+        run: sudo sysctl -w vm.max_map_count=262144
       - name: Docs
         run: task pyDocs
       - name: Run Cluster
@@ -123,11 +121,9 @@ jobs:
         with:
           python-version: '3.6'
           cache: 'pip'
-      - name: Install Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - name: Misc. Setup
-        run: |
-          sudo sysctl -w vm.max_map_count=262144
+        run: sudo sysctl -w vm.max_map_count=262144
       - name: Initialize Submodule
         run: task annbCreateSubmodule
       - name: Install Dependencies
@@ -149,8 +145,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - name: Install Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
           sudo chown -R runneradmin:runneradmin docs
@@ -187,8 +182,7 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - name: Install Task
-        uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: |
           python3 -m pip install setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Misc. Setup
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Compile
-        run: sbt jvmCompile
+        run: task jvmCompile
       - name: Assemble
-        run: sbt jvmAssemble
+        run: task jvmAssemble
       - name: Run Unit Tests
         run: task jvmUnitTestQuick
       - name: Run Cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,10 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
-      - uses: olafurpg/setup-scala@v11
-      - uses: arduino/setup-task@v1
+      - name: Setup SBT
+        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - name: Setup Task
+        uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Compile
@@ -83,7 +85,10 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - uses: arduino/setup-task@v1
+      - name: Setup SBT
+        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - name: Setup Task
+        uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Docs
@@ -117,11 +122,14 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
+      - name: Setup SBT
+        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+      - name: Setup Task
+        uses: arduino/setup-task@v1
       - uses: actions/setup-python@v2
         with:
           python-version: '3.6'
           cache: 'pip'
-      - uses: arduino/setup-task@v1
       - name: Misc. Setup
         run: sudo sysctl -w vm.max_map_count=262144
       - name: Initialize Submodule
@@ -145,7 +153,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: arduino/setup-task@v1
+      - name: Setup Task
+        uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
           sudo chown -R runneradmin:runneradmin docs
@@ -178,14 +187,16 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
+      - name: Setup SBT
+        run: curl -Ls https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - uses: arduino/setup-task@v1
-      - name: Misc. Setup
-        run: |
-          python3 -m pip install setuptools
+      - name: Setup Task
+        uses: arduino/setup-task@v1
+      - name: Setup Setuptools
+        run: python3 -m pip install setuptools
       - name: Publish to PyPi
         run: task pyPublishSnapshot VERSION=$(cat version)-dev${{ github.run_number }}
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,7 @@ jobs:
       - uses: arduino/setup-task@v1
       - name: Compile Jekyll Site
         run: |
-          sudo whoami
-          whoami
-          sudo chown -R runneradmin:runneradmin docs
+          sudo chown -R root:root docs
           task docsCompile
           sudo chown -R runner:docker docs 
           ls -la docs/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   show-github-context:
     name: "Show Github Context"
     timeout-minutes: 1
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   
   test-jvm:
     name: "Test JVM Code"
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ permissions:
 
 jobs:
   release-docs:
-    runs-on: ubuntu-20.04
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 10
     environment:
       name: github-pages
@@ -25,9 +26,9 @@ jobs:
         with:
           python-version: '3.7.5'
           cache: 'pip'
-      - name: Misc. Setup
-        run: |
-          sudo snap install task --classic
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Jekyll Site
         run: |
           sudo chown -R runneradmin:runneradmin docs
@@ -49,7 +50,8 @@ jobs:
         uses: actions/deploy-pages@v1
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on:
+      - ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -71,13 +73,15 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Release Credentials
         env:
           PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
         run: ./.github/scripts/setup-env.sh
-      - run: |
-          sudo snap install task --classic
-          python3 -m pip install setuptools
+      - name: Setup Setuptools
+        run: python3 -m pip install setuptools
       - name: Publish to PyPi
         run: task pyPublishRelease
       - name: Publish to Github

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,7 +159,7 @@ tasks:
   jvmCompile:
     desc: Compile Scala and Java code using SBT
     cmds:
-      - sbt -client ";compile;Test/compile"
+      - sbt -client "compile; Test/compile; IntegrationTest/compile"
 
   jvmAssemble:
     desc: Build the plugin bundle using SBT

--- a/docker/cluster_ready.py
+++ b/docker/cluster_ready.py
@@ -3,7 +3,7 @@ import sys
 from time import sleep
 sys.stdout.write("Waiting for elasticsearch health endpoint")
 req = Request("http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s")
-for i in range(1, 181):
+for i in range(1, 121):
   try:
     res = urlopen(req)
     if res.getcode() == 200:

--- a/docker/cluster_ready.py
+++ b/docker/cluster_ready.py
@@ -3,7 +3,7 @@ import sys
 from time import sleep
 sys.stdout.write("Waiting for elasticsearch health endpoint")
 req = Request("http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s")
-for i in range(1, 121):
+for i in range(1, 181):
   try:
     res = urlopen(req)
     if res.getcode() == 200:


### PR DESCRIPTION
## Related Issue

None

## Changes

- Upgrade all workflows except test-benchmarks to run on ubuntu-22.04.
- Use the setup-task action instead of `snap` to install the task CLI.
- Improve some of the step names

## Testing and Validation

Standard CI