### PR TITLE
Build: only release on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.5'
+          python-version: '3.7.15'
           cache: 'pip'
       - uses: arduino/setup-task@v1
         with:
@@ -60,9 +60,9 @@ jobs:
             ${{ github.workflow }}.${{ github.job }}
           path: |
             **/target/**/*
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.5'
+          python-version: '3.7.15'
           cache: 'pip'
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,5 @@
 name: Release
 on:
-  push:
-    branches: 
-      - main
-
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Related Issue

None

## Changes

- Only run the release workflow on manual dispatch, not automatically
- Upgrade the release to use setup-python@v4

## Testing and Validation

Standard CI