### PR TITLE
Benchmarks: point submodule at ann-benchmarks master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .gradle
 build
 target


### PR DESCRIPTION
## Related Issue

#493

## Changes

Pointing the submodule at the ann-benchmarks master branch after the Elastiknn upgrade PR was merged.

## Testing and Validation

Standard CI