### PR TITLE
Docs: fix Jekyll url and baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,8 @@ title: Elastiknn
 name: Elastiknn
 description: >- # this means to ignore newlines until "baseurl:"
   An Elasticsearch Plugin for Exact and Approximate Nearest Neighbors Search in High Dimensional Vector Spaces
-url: "https://alexklibisz.github.io/elastiknn" 
+url: "https://alexklibisz.github.io"
+baseurl: "elastiknn" 
 
 theme: minimal-mistakes-jekyll
 minimal_mistakes_skin: dark


### PR DESCRIPTION
Fixing the url and baseurl to account for having a path in the URL now.