### PR TITLE
Build: use docker compose instead of docker-compose

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -100,55 +100,55 @@ tasks:
   dockerLogBenchmarkingCluster:
     desc: Print logs from the benchmarking cluster
     cmds:
-      - docker-compose -f docker/docker-compose.benchmarking.yaml logs
+      - docker compose -f docker/docker-compose.benchmarking.yaml logs
       - docker ps -a
 
   dockerLogTestingCluster:
     desc: Print logs from the testing cluster
     cmds:
-      - docker-compose -f docker/docker-compose.testing.yaml logs
+      - docker compose -f docker/docker-compose.testing.yaml logs
       - docker ps -a
 
   dockerRunBenchmarkingCluster:
-    desc: Run a local cluster for benchmarking using docker-compose.
+    desc: Run a local cluster for benchmarking using docker compose.
     deps:
       - installDockerCompose
       - jvmAssemble
     cmds:
-      - docker-compose -f docker/docker-compose.benchmarking.yaml up --detach --build --force-recreate
+      - docker compose -f docker/docker-compose.benchmarking.yaml up --detach --build --force-recreate
       - python3 docker/cluster_ready.py
 
   dockerRunTestingCluster:
-    desc: Run a local cluster for testing using docker-compose.
+    desc: Run a local cluster for testing using docker compose.
     deps:
       - installDockerCompose
       - jvmAssemble
     cmds:
-      - docker-compose -f docker/docker-compose.testing.yaml up --detach --build --force-recreate
+      - docker compose -f docker/docker-compose.testing.yaml up --detach --build --force-recreate
       - python3 docker/cluster_ready.py
 
   dockerStopBenchmarkingCluster:
     desc: Stop the local benchmarking cluster.
     cmds:
-      - docker-compose -f docker/docker-compose.benchmarking.yaml down
+      - docker compose -f docker/docker-compose.benchmarking.yaml down
 
   dockerStopTestingCluster:
     desc: Stop the local testing cluster.
     cmds:
-      - docker-compose -f docker/docker-compose.testing.yaml down
+      - docker compose -f docker/docker-compose.testing.yaml down
 
   docsDev:
     desc: Start local development server.
     dir: docs
     cmds:
-      - docker-compose up dev
+      - docker compose up dev
 
   docsCompile:
     desc: Compile docs into a static site.
     dir: docs
     cmds:
       - rm -rf _site
-      - docker-compose run --rm compile
+      - docker compose run --rm compile
 
   jvmClean:
     desc: Clean all JVM artifacts
@@ -214,11 +214,11 @@ tasks:
       - gh release create --prerelease --generate-notes {{ .VERSION }} --target {{ .COMMIT }} elastiknn-plugin/target/elastiknn-*.zip
 
   installDockerCompose:
-    desc: Install docker-compose using pip
+    desc: Install docker compose using pip
     status:
-      - docker-compose --version
+      - docker compose --version
     cmds:
-      - python3 -m pip install docker-compose
+      - python3 -m pip install docker compose
 
   pyCreateVenv:
     desc: Create python virtual environment

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -217,8 +217,6 @@ tasks:
     desc: Install docker compose using pip
     status:
       - docker compose --version
-    cmds:
-      - python3 -m pip install docker compose
 
   pyCreateVenv:
     desc: Create python virtual environment

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -8,7 +8,7 @@ If you're reading this, there's a chance you'd like to contribute to Elastiknn. 
 
 ### Prerequisites
 
-You need at least the following software installed: git, Java 17, Python3.7, SBT, docker, docker-compose, and [task](https://taskfile.dev).
+You need at least the following software installed: git, Java 17, Python3.7, SBT, docker, docker compose, and [task](https://taskfile.dev).
 I'm assuming you're running on a Linux or MacOS operating system.
 I have no idea if any of this will work on Windows.
 There might be other software which is missing. 
@@ -87,7 +87,7 @@ IntelliJ should stop execution at your breakpoint.
 
 ### Local Cluster
 
-Use `task dockerRunTestingCluster` to run a local cluster with one master node and one data node (using docker-compose).
+Use `task dockerRunTestingCluster` to run a local cluster with one master node and one data node (using docker compose).
 There are a couple parts of the codebase that deal with serializing queries for use in a distributed environment.
 Running this small local cluster exercises those code paths.
 

--- a/docker/docker-compose.testing.yaml
+++ b/docker/docker-compose.testing.yaml
@@ -1,4 +1,4 @@
-# Docker-compose setup for running tests and micro-benchmarks.
+# docker compose setup for running tests and micro-benchmarks.
 # Github's virtual environments have 2 CPUs, 7GB memory, 14GB SSD.
 # Important to run > 1 node because some parts of the plugin
 # deal with communication/serialization between nodes.


### PR DESCRIPTION
## Related Issue

Tangentially related to #525

## Changes

Using `docker compose` command instead of `docker-compose`

## Testing and Validation

Standard Ci