### PR TITLE
Build: use token for pypi releases

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-# PYPI
-echo $PYPIRC_B64 | base64 --decode > $HOME/.pypirc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,10 +177,6 @@ jobs:
     name: Publish Snapshots
     runs-on:
       - ubuntu-22.04
-    needs:
-      - test-jvm
-      - test-python
-      - test-benchmarks
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,11 +188,11 @@ jobs:
         timeout-minutes: 1
         with:
           fetch-depth: 0 # Needed for git-based changelog.
-      - name: Setup Release Credentials
+      - name: Setup pypirc file
         timeout-minutes: 1
         env:
-          PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
-        run: ./.github/scripts/setup-env.sh
+          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+        run: envsubst .github/workflows/pypirc.template > $HOME/.pypirc
       - uses: actions/setup-java@v3
         timeout-minutes: 1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,8 @@ jobs:
         timeout-minutes: 1
         env:
           TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
-        run: envsubst .github/workflows/pypirc.template > $HOME/.pypirc
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: envsubst < .github/workflows/pypirc.template > $HOME/.pypirc
       - uses: actions/setup-java@v3
         timeout-minutes: 1
         with:

--- a/.github/workflows/pypirc.template
+++ b/.github/workflows/pypirc.template
@@ -1,3 +1,7 @@
 [testpypi]
   username = __token__
-  password = ${TESTPYPI_PASSWORD}
+  password = ${TESTPYPI_TOKEN}
+
+[pypi]
+  username = __token__
+  password = ${PYPI_TOKEN}

--- a/.github/workflows/pypirc.template
+++ b/.github/workflows/pypirc.template
@@ -1,0 +1,3 @@
+[testpypi]
+  username = __token__
+  password = ${TESTPYPI_PASSWORD}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,11 @@ jobs:
       - uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Release Credentials
+      - name: Setup pypirc file
         env:
-          PYPIRC_B64: ${{ secrets.PYPIRC_B64 }}
-        run: ./.github/scripts/setup-env.sh
+          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: envsubst < .github/workflows/pypirc.template > $HOME/.pypirc
       - name: Setup Setuptools
         run: python3 -m pip install setuptools
       - name: Publish to PyPi


### PR DESCRIPTION
## Related Issue

#561

## Changes

Switching from password-based auth to token-based auth on test.pypi.org and pypi.org. I created tokens on test.pypi.org and pypi.org, set them as repo secrets, and modified the release jobs so that they substitute the tokens into the ~/.pypirc file.

## Testing and Validation

This worked locally:

```bash
➜  elastiknn git:(fix-pypi) envsubst < .github/workflows/pypirc.template > ~/.pypirc   
➜  elastiknn git:(fix-pypi) task pyPublishSnapshot                                  
task: Task "pyCreateVenv" is up to date
task: [pyInstallRequirements] venv/bin/pip install --quiet -r requirements.txt

[notice] A new release of pip is available: 23.2.1 -> 23.3.1
[notice] To update, run: /Users/alex/Development/repos/elastiknn/client-python/venv/bin/python -m pip install --upgrade pip
task: [pyInstallRequirements] venv/bin/pip install --quiet -r requirements-build.txt

[notice] A new release of pip is available: 23.2.1 -> 23.3.1
[notice] To update, run: /Users/alex/Development/repos/elastiknn/client-python/venv/bin/python -m pip install --upgrade pip
task: [pyPublishLocal] rm -rf dist
task: [pyPublishLocal] venv/bin/python setup.py --version 8.8.0.0 sdist bdist_wheel
running sdist
running egg_info
writing elastiknn_client.egg-info/PKG-INFO
writing dependency_links to elastiknn_client.egg-info/dependency_links.txt
writing requirements to elastiknn_client.egg-info/requires.txt
writing top-level names to elastiknn_client.egg-info/top_level.txt
reading manifest file 'elastiknn_client.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*.pyi' under directory 'elastiknn'
warning: no files found matching '*.proto' under directory 'elastiknn'
writing manifest file 'elastiknn_client.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating elastiknn-client-8.8.0.0
creating elastiknn-client-8.8.0.0/elastiknn
creating elastiknn-client-8.8.0.0/elastiknn_client.egg-info
creating elastiknn-client-8.8.0.0/tests
copying files to elastiknn-client-8.8.0.0...
copying MANIFEST.in -> elastiknn-client-8.8.0.0
copying setup.py -> elastiknn-client-8.8.0.0
copying elastiknn/__init__.py -> elastiknn-client-8.8.0.0/elastiknn
copying elastiknn/api.py -> elastiknn-client-8.8.0.0/elastiknn
copying elastiknn/client.py -> elastiknn-client-8.8.0.0/elastiknn
copying elastiknn/codec.py -> elastiknn-client-8.8.0.0/elastiknn
copying elastiknn/models.py -> elastiknn-client-8.8.0.0/elastiknn
copying elastiknn/utils.py -> elastiknn-client-8.8.0.0/elastiknn
copying elastiknn_client.egg-info/PKG-INFO -> elastiknn-client-8.8.0.0/elastiknn_client.egg-info
copying elastiknn_client.egg-info/SOURCES.txt -> elastiknn-client-8.8.0.0/elastiknn_client.egg-info
copying elastiknn_client.egg-info/dependency_links.txt -> elastiknn-client-8.8.0.0/elastiknn_client.egg-info
copying elastiknn_client.egg-info/requires.txt -> elastiknn-client-8.8.0.0/elastiknn_client.egg-info
copying elastiknn_client.egg-info/top_level.txt -> elastiknn-client-8.8.0.0/elastiknn_client.egg-info
copying tests/test_client.py -> elastiknn-client-8.8.0.0/tests
copying tests/test_model.py -> elastiknn-client-8.8.0.0/tests
copying tests/test_utils.py -> elastiknn-client-8.8.0.0/tests
Writing elastiknn-client-8.8.0.0/setup.cfg
creating dist
Creating tar archive
removing 'elastiknn-client-8.8.0.0' (and everything under it)
running bdist_wheel
running build
running build_py
/Users/alex/Development/repos/elastiknn/client-python/venv/lib/python3.10/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
installing to build/bdist.macosx-13.3-arm64/wheel
running install
running install_lib
creating build/bdist.macosx-13.3-arm64/wheel
creating build/bdist.macosx-13.3-arm64/wheel/elastiknn
copying build/lib/elastiknn/models.py -> build/bdist.macosx-13.3-arm64/wheel/elastiknn
copying build/lib/elastiknn/client.py -> build/bdist.macosx-13.3-arm64/wheel/elastiknn
copying build/lib/elastiknn/__init__.py -> build/bdist.macosx-13.3-arm64/wheel/elastiknn
copying build/lib/elastiknn/api.py -> build/bdist.macosx-13.3-arm64/wheel/elastiknn
copying build/lib/elastiknn/utils.py -> build/bdist.macosx-13.3-arm64/wheel/elastiknn
copying build/lib/elastiknn/codec.py -> build/bdist.macosx-13.3-arm64/wheel/elastiknn
running install_egg_info
Copying elastiknn_client.egg-info to build/bdist.macosx-13.3-arm64/wheel/elastiknn_client-8.8.0.0-py3.10.egg-info
running install_scripts
creating build/bdist.macosx-13.3-arm64/wheel/elastiknn_client-8.8.0.0.dist-info/WHEEL
creating 'dist/elastiknn_client-8.8.0.0-py3-none-any.whl' and adding 'build/bdist.macosx-13.3-arm64/wheel' to it
adding 'elastiknn/__init__.py'
adding 'elastiknn/api.py'
adding 'elastiknn/client.py'
adding 'elastiknn/codec.py'
adding 'elastiknn/models.py'
adding 'elastiknn/utils.py'
adding 'elastiknn_client-8.8.0.0.dist-info/METADATA'
adding 'elastiknn_client-8.8.0.0.dist-info/WHEEL'
adding 'elastiknn_client-8.8.0.0.dist-info/top_level.txt'
adding 'elastiknn_client-8.8.0.0.dist-info/RECORD'
removing build/bdist.macosx-13.3-arm64/wheel
task: [pyPublishLocal] ls dist
elastiknn-client-8.8.0.0.tar.gz                 elastiknn_client-8.8.0.0-py3-none-any.whl
task: [pyPublishSnapshot] venv/bin/python -m twine upload -r testpypi --verbose dist/*
INFO     Using configuration from /Users/alex/.pypirc                                                                                                                                               
Uploading distributions to https://test.pypi.org/legacy/
INFO     dist/elastiknn_client-8.8.0.0-py3-none-any.whl (7.5 KB)                                                                                                                                    
INFO     dist/elastiknn-client-8.8.0.0.tar.gz (7.9 KB)                                                                                                                                              
INFO     username set from config file                                                                                                                                                              
INFO     password set from config file                                                                                                                                                              
INFO     username: __token__                                                                                                                                                                        
INFO     password: <hidden>                                                                                                                                                                         
Uploading elastiknn_client-8.8.0.0-py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.9/10.9 kB • 00:00 • ?
INFO     Response from https://test.pypi.org/legacy/:                                                                                                                                               
         200 OK                                                                                                                                                                                     
Uploading elastiknn-client-8.8.0.0.tar.gz
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.3/11.3 kB • 00:00 • ?
INFO     Response from https://test.pypi.org/legacy/:                                                                                                                                               
         200 OK                                                                                                                                                                                     

View at:
https://test.pypi.org/project/elastiknn-client/8.8.0.0/
```

This change is also exercised by the publish-snapshots job.

