### PR TITLE
Build: fix python version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0 # Needed for git-based changelog.
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.15'
+          python-version: '3.10.8'
           cache: 'pip'
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Same as #563, except this time I'm including the actual change. 