### PR TITLE
Build: run scala-steward once/month

### DIFF
--- a/.github/workflows/scala-steward.yaml
+++ b/.github/workflows/scala-steward.yaml
@@ -2,7 +2,7 @@ name: Scala Steward
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 16 * * 1'
+    - cron: '0 0 6 * *'
 jobs:
   scala-steward:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Related Issue

None

## Changes

Running scala-steward once/month instead of once/week. Don't have time to review the PRs weekly, and the benefit is negligible.

## Testing and Validation

Set it to the sixth, so we'll see if it runs tonight.