### PR TITLE
client-python: remove dependency on dataclasses

### DIFF
--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -1,4 +1,3 @@
 elasticsearch==8.9.0
-dataclasses-json==0.3.7
 tqdm==4.61.1
 scipy==1.10.1


### PR DESCRIPTION
## Related Issue

None

## Changes

Dataclasses are part of the language in newer versions of Python. At this point we shouldn't need the dependency anymore.

## Testing and Validation

Standard CI