### PR TITLE
Build: increase testing memory

### DIFF
--- a/docker/docker-compose.testing.yaml
+++ b/docker/docker-compose.testing.yaml
@@ -22,8 +22,8 @@ services:
       - xpack.security.enabled=false
     ports:
       - "9200:9200"
-    mem_limit: 700m
-    mem_reservation: 700m
+    mem_limit: 900m
+    mem_reservation: 900m
     cpus: 0.5
     ulimits:
       nofile:


### PR DESCRIPTION
## Related Issue

N/A

## Changes

Increasing memory in the testing master service because it was OOMing locally.

## Testing and Validation

Standard CI