### PR TITLE
Docs: fix image URLs

### DIFF
--- a/docs/_posts/2020-12-15-elastic-meetup-presentation-demo-december-2020.md
+++ b/docs/_posts/2020-12-15-elastic-meetup-presentation-demo-december-2020.md
@@ -18,4 +18,4 @@ The demo is available [as a notebook in the Github repo.](https://github.com/ale
 
 Here are the slides:
 
-<iframe width="800" height="420" src="/assets/downloads/elastic-meetup-2020-12-15-slides.pdf" frameborder="0" allowfullscreen></iframe>
+<iframe width="800" height="420" src="/elastiknn/assets/downloads/elastic-meetup-2020-12-15-slides.pdf" frameborder="0" allowfullscreen></iframe>

--- a/docs/_posts/2021-07-30-how-does-elastiknn-work.md
+++ b/docs/_posts/2021-07-30-how-does-elastiknn-work.md
@@ -284,7 +284,7 @@ Elasticsearch and Lucene handle everything else: serving requests, indexing docu
 
 Without further ado, behold the boxes and arrows:
 
-<img src="/assets/images/how-does-elastiknn-work-00.jpg" alt="Diagram overview of Elastiknn"/>
+<img src="/elastiknn/assets/images/how-does-elastiknn-work-00.jpg" alt="Diagram overview of Elastiknn"/>
 
 The most important and interesting parts of Elastiknn are the LSH models and the custom `MatchHashesAndScoreQuery`.
 The LSH models are used in the `TypeMapper` and `KnnQueryBuilder` to convert vectors into Lucene fields.


### PR DESCRIPTION
## Related Issue

N/A

## Changes

The images on the posts are broken. I guess this happened when I changed the site URL, #442 

<img width="646" alt="image" src="https://github.com/alexklibisz/elastiknn/assets/8015228/a32ded04-8e20-4a49-83a5-319ac1432f24">\

## Testing and Validation

Will merge, release docs, and verify they're fixed