### PR TITLE
Refactor: Add EmptyHitCounter for use in MatchHashesAndScoreQuerySuite

### DIFF
--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/EmptyHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/EmptyHitCounter.java
@@ -1,0 +1,46 @@
+package com.klibisz.elastiknn.search;
+
+import org.apache.lucene.search.KthGreatest;
+
+public final class EmptyHitCounter implements HitCounter {
+    @Override
+    public void increment(int key, short count) {}
+
+    @Override
+    public void increment(int key, int count) {}
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public short get(int key) {
+        return 0;
+    }
+
+    @Override
+    public int numHits() {
+        return 0;
+    }
+
+    @Override
+    public int capacity() {
+        return 0;
+    }
+
+    @Override
+    public int minKey() {
+        return 0;
+    }
+
+    @Override
+    public int maxKey() {
+        return 0;
+    }
+
+    @Override
+    public KthGreatest.Result kthGreatest(int k) {
+        return new KthGreatest.Result((short) 0, 0, 0);
+    }
+}

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -2,6 +2,7 @@ package org.apache.lucene.search;
 
 import com.klibisz.elastiknn.models.HashAndFreq;
 import com.klibisz.elastiknn.search.ArrayHitCounter;
+import com.klibisz.elastiknn.search.EmptyHitCounter;
 import com.klibisz.elastiknn.search.HitCounter;
 import org.apache.lucene.index.*;
 import org.apache.lucene.util.BytesRef;
@@ -58,7 +59,7 @@ public class MatchHashesAndScoreQuery extends Query {
                 Terms terms = reader.terms(field);
                 // terms seem to be null after deleting docs. https://github.com/alexklibisz/elastiknn/issues/158
                 if (terms == null) {
-                    return new ArrayHitCounter(0);
+                    return new EmptyHitCounter();
                 } else {
                     TermsEnum termsEnum = terms.iterator();
                     PostingsEnum docs = null;


### PR DESCRIPTION
## Related Issue

None

## Changes

Added an EmptyHitCounter for cases where `reader.terms` returns null. Just an improvement for aesthetics and code clarity, no actual impact on performance.

## Testing and Validation

Standard CI