### PR TITLE
Performance: optimize MatchHashesAndScoreQuery for case where a hash occurs once

### DIFF
--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -22,6 +22,15 @@ public class ArrayHitCounter implements HitCounter {
     }
 
     @Override
+    public void increment(int key) {
+        if (counts[key]++ == 0) {
+            numHits++;
+            minKey = Math.min(key, minKey);
+            maxKey = Math.max(key, maxKey);
+        }
+    }
+
+    @Override
     public void increment(int key, short count) {
         if ((counts[key] += count) == count) {
             numHits++;

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/EmptyHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/EmptyHitCounter.java
@@ -3,6 +3,10 @@ package com.klibisz.elastiknn.search;
 import org.apache.lucene.search.KthGreatest;
 
 public final class EmptyHitCounter implements HitCounter {
+
+    @Override
+    public void increment(int key) {}
+
     @Override
     public void increment(int key, short count) {}
 

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/HitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/HitCounter.java
@@ -7,6 +7,8 @@ import org.apache.lucene.search.KthGreatest;
  */
 public interface HitCounter {
 
+    void increment(int key);
+
     void increment(int key, short count);
 
     boolean isEmpty();

--- a/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
+++ b/elastiknn-lucene/src/main/java/org/apache/lucene/search/MatchHashesAndScoreQuery.java
@@ -67,10 +67,19 @@ public class MatchHashesAndScoreQuery extends Query {
                     // TODO: Is this the right place to use the live docs bitset to check for deleted docs?
                     // Bits liveDocs = reader.getLiveDocs();
                     for (HashAndFreq hf : hashAndFrequencies) {
-                        if (termsEnum.seekExact(new BytesRef(hf.hash))) {
-                            docs = termsEnum.postings(docs, PostingsEnum.NONE);
-                            while (docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                                counter.increment(docs.docID(), (short) min(hf.freq, docs.freq()));
+                        if (hf.freq == 1) {
+                            if (termsEnum.seekExact(new BytesRef(hf.hash))) {
+                                docs = termsEnum.postings(docs, PostingsEnum.NONE);
+                                while (docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                                    counter.increment(docs.docID());
+                                }
+                            }
+                        } else {
+                            if (termsEnum.seekExact(new BytesRef(hf.hash))) {
+                                docs = termsEnum.postings(docs, PostingsEnum.NONE);
+                                while (docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                                    counter.increment(docs.docID(), (short) min(hf.freq, docs.freq()));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Related Issue

#611

## Changes

There is one LSH model (PermutationLsh) which can emit the same hash multiple times. Because of this, MatchHashesAndScoreQuery has to account for the fact that the same hash can occur multiple times. Through some trial and error, I figured out that this actually has a measurable impact on performance. 

So this PR adds an optimized case to MatchHashesAndScoreQuery for hashes that occur once.

## Testing and Validation

How was it validated?