### PR TITLE
Performance: benchmark on r6i.xlarge

### DIFF
--- a/docs/pages/performance.md
+++ b/docs/pages/performance.md
@@ -8,7 +8,7 @@ classes: wide
 
 ## Method
 
-The results on this page are produced by running elastiknn on the ann-benchmarks benchmark on an AWS EC2 r6i.8xlarge instance.
+The results on this page are produced by running elastiknn on the ann-benchmarks benchmark on an AWS EC2 r6i.xlarge instance.
 We use `task dockerStartBenchmarkingCluster` to start a single-node benchmarking cluster `task annbRunLocalFashionMnist` to run the benchmark.
 
 See the ann-benchmarks directory in the Elastiknn repository for more details.


### PR DESCRIPTION
## Related Issue

#611 

## Changes

Trying to run benchmarks on a smaller EC2 instance. The r6i.8xlarge has 32 cores which is really overkill for what's effectively a single-threaded benchmark.

## Testing and Validation

Running benchmarks on r6i.xlarge.