### PR TITLE
Build: run workflows on self-hosted hetzner runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
         run: |
-          sudo chown -R root:root docs
+          sleep 99999
+          sudo chown -R runner:docker docs
           task docsCompile
           sudo chown -R runner:docker docs
           ls -la docs/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
     name: Test Jekyll Site
     runs-on:
       - elastiknn-cx41
-    timeout-minutes: 10
+#    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         timeout-minutes: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
     name: Test Jekyll Site
     runs-on:
       - elastiknn-cx41
-#    timeout-minutes: 10
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         timeout-minutes: 1
@@ -171,6 +171,5 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
         run: |
-          tail -f /dev/null
           task docsCompile
-          ls -la docs/*
+          du -hs docs/_site

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: "Show Github Context"
     timeout-minutes: 1
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   test-jvm:
     name: "Test JVM Code"
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     steps:
       - uses: actions/checkout@v3
         timeout-minutes: 1
@@ -70,7 +70,7 @@ jobs:
   test-python:
     name: Test Python Client Code
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     steps:
       - uses: actions/checkout@v3
         timeout-minutes: 1
@@ -113,7 +113,7 @@ jobs:
   test-benchmarks:
     name: Test Benchmarks
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
   test-jekyll-site:
     name: Test Jekyll Site
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,9 +170,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
+        # Have to change ownership here because the jekyll container runs as the root user.
+        # Without this change, we get errors when writing the site files to the mounted directory.
         run: |
-          sleep 99999
-          sudo chown -R runner:docker docs
+          sudo chown -R root:root docs
           task docsCompile
           sudo chown -R runner:docker docs
           ls -la docs/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: "Show Github Context"
     timeout-minutes: 1
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:
@@ -70,7 +70,7 @@ jobs:
   test-python:
     name: Test Python Client Code
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     steps:
       - uses: actions/checkout@v3
         timeout-minutes: 1
@@ -113,7 +113,7 @@ jobs:
   test-benchmarks:
     name: Test Benchmarks
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
   test-jekyll-site:
     name: Test Jekyll Site
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,11 @@ jobs:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:
       - run: echo $GITHUB_CONTEXT
-  
+
   test-jvm:
     name: "Test JVM Code"
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     steps:
       - uses: actions/checkout@v3
         timeout-minutes: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,10 +170,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
-        # Have to change ownership here because the jekyll container runs as the root user.
-        # Without this change, we get errors when writing the site files to the mounted directory.
         run: |
-          sudo chown -R root:root docs
+          tail -f /dev/null
           task docsCompile
-          sudo chown -R runner:docker docs
           ls -la docs/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,5 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
         run: |
-          sudo chown -R runneradmin:runneradmin docs
           task docsCompile
-          sudo chown -R runner:docker docs 
           ls -la docs/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,5 +171,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Jekyll Site
         run: |
+          sudo chown -R root:root docs
           task docsCompile
+          sudo chown -R runner:docker docs
           ls -la docs/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release-plugin:
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
   release-python-client:
     needs: release-plugin
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
     needs: release-python-client
     if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.full-release == 'true' }}
     runs-on:
-      - ubuntu-22.04
+      - elastiknn-ccx23
     timeout-minutes: 10
     environment:
       name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release-plugin:
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
   release-python-client:
     needs: release-plugin
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
     needs: release-python-client
     if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.full-release == 'true' }}
     runs-on:
-      - elastiknn-ccx23
+      - elastiknn-cx41
     timeout-minutes: 10
     environment:
       name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Jekyll Site
-        run: |
-          sudo chown -R runneradmin:runneradmin docs
-          task docsCompile
-          sudo chown -R runner:docker docs
+        run: task docsCompile
       - name: Generate Python Docs
         run: |
           task pyDocs

--- a/.github/workflows/scala-steward.yaml
+++ b/.github/workflows/scala-steward.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 6 * *'
 jobs:
   scala-steward:
-    runs-on: ubuntu-22.04
+    runs-on: elastiknn-ccx23
     name: Launch Scala Steward
     steps:
       - name: Scala Steward

--- a/.github/workflows/scala-steward.yaml
+++ b/.github/workflows/scala-steward.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 6 * *'
 jobs:
   scala-steward:
-    runs-on: elastiknn-ccx23
+    runs-on: elastiknn-cx41
     name: Launch Scala Steward
     steps:
       - name: Scala Steward

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -5,10 +5,11 @@ services:
   # Local development server with automatic recompilation.
   dev:
     container_name: elastiknn-docs-dev
-    image: jekyll/jekyll:4.0
+    image: ruby:3.1.1
     volumes:
-      - ".:/srv/jekyll"
-      - "./.gemcache:/usr/gem/cache"
+      - ".:/mnt/docs"
+      - "./.gemcache:/usr/local/bundle/cache"
+    working_dir: '/mnt/docs'
     command:
       - "/bin/bash"
       - "-ec"
@@ -21,15 +22,16 @@ services:
   # Build site for publication. Output is in site/_site.
   compile:
     container_name: elastiknn-docs-build
-    image: jekyll/jekyll:4.0
+    image: ruby:3.1.1
     volumes:
-      - ".:/srv/jekyll:z"
-      - "./.gemcache:/usr/gem/cache"
+      - ".:/mnt/docs"
+      - "./.gemcache:/usr/local/bundle/cache"
+    working_dir: '/mnt/docs'
+    environment:
+      - JEKYLL_ENV=production
     command:
       - "/bin/bash"
       - "-ec"
       - |
         bundle install
         bundle exec jekyll build
-    environment:
-      - JEKYLL_ENV=production

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -29,9 +29,9 @@ services:
       - "/bin/bash"
       - "-ec"
       - |
-        sudo chown -R root:root docs
+        chown -R root:root docs
         bundle install
-        sudo chown -R runner:docker docs
+        chown -R runner:docker docs
         bundle exec jekyll build
     environment:
       - JEKYLL_ENV=production

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -29,9 +29,7 @@ services:
       - "/bin/bash"
       - "-ec"
       - |
-        chown -R root:root docs
         bundle install
-        chown -R runner:docker docs
         bundle exec jekyll build
     environment:
       - JEKYLL_ENV=production

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -29,7 +29,9 @@ services:
       - "/bin/bash"
       - "-ec"
       - |
+        sudo chown -R root:root docs
         bundle install
+        sudo chown -R runner:docker docs
         bundle exec jekyll build
     environment:
       - JEKYLL_ENV=production


### PR DESCRIPTION
## Related Issue

No related issue. I'm experimenting with using Hetzner for Github Actions runners.

## Changes

Moving CI, release, and scala-steward workflows onto self-hosted runners on Hetzner.

I had to wrestle a bit with the Jekyll container, but I ended up actually simplifying the overall Jekyll setup.

## Testing and Validation

The CI workflow passes. I'll test the release and scala-steward workflows after merging, but they mostly do the same things as the CI workflow, so should be good too.