### PR TITLE
160_b avoid return zero hits

### DIFF
--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -70,7 +70,7 @@ public final class ArrayHitCounter implements HitCounter {
         // accumulating counts of counts until we've exceeded k.
         int numGreaterEqual = 0;
         short kthGreatest = maxValue;
-        while (kthGreatest > 0) {
+        while (kthGreatest > 1) {
             numGreaterEqual += hist[kthGreatest];
             if (numGreaterEqual > k) break;
             else kthGreatest--;
@@ -125,7 +125,7 @@ public final class ArrayHitCounter implements HitCounter {
                             if (counts[docID] > kgr.kthGreatest) {
                                 numEmitted++;
                                 return docID;
-                            } else if (counts[docID] == kgr.kthGreatest && numEq < candidates - kgr.numGreaterThan) {
+                            } else if (counts[docID] == kgr.kthGreatest && numEq < kgr.numNonZero - kgr.numGreaterThan) {
                                 numEq++;
                                 numEmitted++;
                                 return docID;


### PR DESCRIPTION
## Related Issue

Link the related issues as a markdown list.
- #714 related to this discussion
## Changes

Te lower limit when checking for frequencies and the max number of hits to consider (it is not candidates, but the nonzero) 

## Testing and Validation

I checked adding some logs in my installation and discovering that it was retrieving too much documents