### PR TITLE
Plugin: stop considering docs with zero LSH hash matches

### DIFF
--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/ArrayHitCounter.java
@@ -70,17 +70,17 @@ public final class ArrayHitCounter implements HitCounter {
         // accumulating counts of counts until we've exceeded k.
         int numGreaterEqual = 0;
         short kthGreatest = maxValue;
-        while (kthGreatest > 0) {
+
+        while (true) {
             numGreaterEqual += hist[kthGreatest];
-            if (numGreaterEqual > k) break;
-            else kthGreatest--;
+            if (kthGreatest > 1 && numGreaterEqual < k) kthGreatest--;
+            else break;
         }
 
         // Finally we find the number that were greater than the kth greatest count.
         // There's a special case if kthGreatest is zero, then the number that were greater is the number of hits.
         int numGreater = numGreaterEqual - hist[kthGreatest];
-        if (kthGreatest == 0) numGreater = numHits;
-        return new KthGreatestResult(kthGreatest, numGreater, numHits);
+        return new KthGreatestResult(kthGreatest, numGreater);
     }
 
     @Override

--- a/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/KthGreatestResult.java
+++ b/elastiknn-lucene/src/main/java/com/klibisz/elastiknn/search/KthGreatestResult.java
@@ -3,11 +3,9 @@ package com.klibisz.elastiknn.search;
 public class KthGreatestResult {
     public final short kthGreatest;
     public final int numGreaterThan;
-    public final int numNonZero;
-    public KthGreatestResult(short kthGreatest, int numGreaterThan, int numNonZero) {
+    public KthGreatestResult(short kthGreatest, int numGreaterThan) {
         this.kthGreatest = kthGreatest;
         this.numGreaterThan = numGreaterThan;
-        this.numNonZero = numNonZero;
     }
 
     @Override
@@ -17,12 +15,12 @@ public class KthGreatestResult {
         } else if (!(o instanceof KthGreatestResult other)) {
             return false;
         } else {
-            return kthGreatest == other.kthGreatest && numGreaterThan == other.numGreaterThan && numNonZero == other.numNonZero;
+            return kthGreatest == other.kthGreatest && numGreaterThan == other.numGreaterThan;
         }
     }
 
     @Override
     public String toString() {
-        return String.format("KthGreatestResult(kthGreatest=%d, numGreaterThan=%d, numNonZero=%d)", kthGreatest, numGreaterThan, numNonZero);
+        return String.format("KthGreatestResult(kthGreatest=%d, numGreaterThan=%d)", kthGreatest, numGreaterThan);
     }
 }

--- a/elastiknn-lucene/src/test/scala/com/klibisz/elastiknn/search/ArrayHitCounterSpec.scala
+++ b/elastiknn-lucene/src/test/scala/com/klibisz/elastiknn/search/ArrayHitCounterSpec.scala
@@ -49,12 +49,16 @@ final class ArrayHitCounterSpec extends AnyFreeSpec with Matchers {
         // This is a hack to replicate a bug in how we emit doc IDs.
         // Basically if the kth greatest value is zero, we end up emitting docs that were never matched,
         // so we need to fill the map with zeros to replicate the behavior here.
-        val minKey = counts.keys.min
-        val maxKey = counts.keys.max
-        (minKey to maxKey).foreach(k => counts.update(k, counts(k)))
+//        val minKey = counts.keys.min
+//        val maxKey = counts.keys.max
+//        (minKey to maxKey).foreach(k => counts.update(k, counts(k)))
+
+//        println(s"Reference counts: ${counts.toList.sorted}")
 
         val valuesSorted = counts.values.toArray.sorted.reverse
         val kthGreatest = valuesSorted.take(k).last
+//        println(s"Reference k=$k")
+//        println(s"Reference kthGreatest=$kthGreatest")
         val greaterDocIds = counts.filter(_._2 > kthGreatest).keys.toArray
         val equalDocIds = counts.filter(_._2 == kthGreatest).keys.toArray.sorted.take(k - greaterDocIds.length)
         val selectedDocIds = (equalDocIds ++ greaterDocIds).sorted
@@ -116,8 +120,8 @@ final class ArrayHitCounterSpec extends AnyFreeSpec with Matchers {
         ahc.get(doc) shouldBe ref.get(doc)
       }
       val k = rng.nextInt(numDocs)
-      val actualDocIds = consumeDocIdSetIterator(ahc.docIdSetIterator(k))
       val referenceDocIds = consumeDocIdSetIterator(ref.docIdSetIterator(k))
+      val actualDocIds = consumeDocIdSetIterator(ahc.docIdSetIterator(k))
 
       referenceDocIds shouldBe actualDocIds
     }
@@ -131,8 +135,7 @@ final class ArrayHitCounterSpec extends AnyFreeSpec with Matchers {
     ahc.increment(0)
     ahc.increment(9)
     val docIds = consumeDocIdSetIterator(ahc.docIdSetIterator(10))
-    docIds shouldBe List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
     // Once the bug is fixed, this should be the correct result:
-    // docIds shouldBe List(0, 9)
+    docIds shouldBe List(0, 9)
   }
 }


### PR DESCRIPTION
## Related Issue

#715 

## Changes

Updated ArrayHitCounter so that it omits docs that had zero hash matches.

## Testing and Validation

WIP