### PR TITLE
#785: fix java.security.AccessControlException caused by ClassTag 

### DIFF
--- a/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/Vec.scala
+++ b/elastiknn-api4s/src/main/scala/com/klibisz/elastiknn/api/Vec.scala
@@ -48,7 +48,7 @@ object Vec {
       case _                 => false
     }
 
-    override def toString: String = s"DenseFloat(${values.take(3).map(n => f"$n%.2f").mkString(",")},...,${values.length})"
+    override def toString: String = s"DenseFloat(${values.take(3).iterator.map(n => f"$n%.2f").mkString(",")},...,${values.length})"
 
     def dot(other: DenseFloat): Float = {
       var (i, dp) = (0, 0f)


### PR DESCRIPTION
fix java.security.AccessControlException caused by ClassTag from DenseFloat.toString

## Related Issue

Link the related issues as a markdown list.

- #785
- #393
- #656

## Changes

the call values.take(3).map(n => f"$n%.2f")   will trigger scala.reflect.ClassTag
so change the call chain to  values.take(3).iterator.map(n => f"$n%.2f") ，which can avoid calling this scala.reflect.ClassTag


## Testing and Validation

```
curl -H'Content-Type: application/json' -X GET http://localhost:9200/my-vector-index4/_search -d'{
    "query": {
        "elastiknn_nearest_neighbors": {
            "field": "my_vec1",
            "vec": {
                "values": [1,1,1,1,1,1,1,1,1,1]
            },
            "model": "lsh",
            "similarity": "jaccard",
            "candidates": 50
        }
    }
}'
{"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: Query [JaccardLsh(my_vec1,50,DenseFloat(1.00,1.00,1.00,...,10))] is not compatible with mapping [JaccardLsh(10,99,1)]","index_uuid":"IUF6fodOS3OigtCpwyRYSQ","index":"my-vector-index4"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"my-vector-index4","node":"o8ebU64GQTG54LQHw0ExDA","reason":{"type":"query_shard_exception","reason":"failed to create query: Query [JaccardLsh(my_vec1,50,DenseFloat(1.00,1.00,1.00,...,10))] is not compatible with mapping [JaccardLsh(10,99,1)]","index_uuid":"IUF6fodOS3OigtCpwyRYSQ","index":"my-vector-index4","caused_by":{"type":"elastiknn_illegal_argument_exception","reason":"Query [JaccardLsh(my_vec1,50,DenseFloat(1.00,1.00,1.00,...,10))] is not compatible with mapping [JaccardLsh(10,99,1)]"}}}]},"status":400}
```

This solution can prevent the server from crashing

How was it validated?