### PR TITLE
Add Claude Code setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(task:*)",
       "Bash(sbt -client:*)",
-      "Bash(git:*)"
+      "Bash(git:*)",
+      "Bash(gh release list:*)"
     ]
   }
 }

--- a/.claude/skills/upgrade-elasticsearch/SKILL.md
+++ b/.claude/skills/upgrade-elasticsearch/SKILL.md
@@ -24,4 +24,4 @@ Upgrade Elasticsearch to the version specified by the user. If no version is spe
 
 5. **Verify integration tests:** `task dockerRunTestingCluster` then `task jvmIntegrationTest`. Fix any failures.
 
-Once all steps pass, open a PR.
+Once all steps pass, open a PR with the title `Dependencies: upgrade Elasticsearch to <new version>` (e.g. `Dependencies: upgrade Elasticsearch to 8.18.5`).

--- a/.claude/skills/upgrade-elasticsearch/SKILL.md
+++ b/.claude/skills/upgrade-elasticsearch/SKILL.md
@@ -4,7 +4,7 @@ description: Upgrade Elasticsearch end-to-end: bump versions, check Lucene, comp
 argument-hint: "[target version, e.g. 8.18.5]"
 ---
 
-Upgrade Elasticsearch to the version specified by the user (or infer it from context). Follow these steps in order, fixing any issues before moving to the next step:
+Upgrade Elasticsearch to the version specified by the user. If no version is specified, run `gh release list --repo elastic/elasticsearch --limit 60` and pick the closest available version to the current one (i.e., the next patch or minor release — minimize the version jump). Follow these steps in order, fixing any issues before moving to the next step:
 
 1. **Bump versions** in all four places:
    - `ElasticsearchVersion` in `build.sbt`


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: build/test commands, project structure, key version variables, dependency upgrade process, and SIMD/JIT gotcha
- `.claude/skills/upgrade-elasticsearch`: `/upgrade-elasticsearch` skill with a step-by-step process for ES upgrades (bump versions, check Lucene eviction, compile, unit tests, integration tests, open PR)
- `.claude/settings.json`: pre-approves `task *` and `sbt -client *` commands so Claude doesn't prompt for each one

🤖 Generated with [Claude Code](https://claude.com/claude-code)