### PR TITLE
Dependencies: update circe 0.14.14 -> 0.14.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ Global / scalaVersion := "3.3.7"
 
 Global / scalacOptions += "-explain"
 
-lazy val CirceVersion = "0.14.14"
+lazy val CirceVersion = "0.14.15"
 lazy val ElasticsearchVersion = "9.3.3"
 lazy val Elastic4sVersion = "9.3.0"
 lazy val ElastiknnVersion = IO.read(file("version")).strip()


### PR DESCRIPTION
Rebases #813 on current main to resolve conflict.

- circe-generic, circe-parser: 0.14.14 → 0.14.15

Closes #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)